### PR TITLE
Add push-to-deploy workflow for the self-hosted server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy to home server
+
+# Push-to-deploy without exposing anything to the public internet.
+#
+# The Coolify instance is bound to loopback and published only on the tailnet via
+# `tailscale serve`. This job joins the tailnet as a short-lived, tagged node for
+# the duration of the run, calls the Coolify API over it, and leaves. Nothing is
+# reachable from the internet at any point.
+#
+# A failing build is safe: Coolify builds the new image first and only swaps
+# traffic once the new container is up, so a bad commit fails this job and leaves
+# the previous container serving.
+
+on:
+  push:
+    branches: [release/rust-web-app]
+  workflow_dispatch:
+
+# Never let two deployments of the same app overlap.
+concurrency:
+  group: deploy-church-powerpoint
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Join the tailnet
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Trigger deployment and wait for the result
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          COOLIFY_BASE: https://homeserver.tail724b7f.ts.net/api/v1
+          APP_UUID: wom00g24u7k5zlfq7x74z358
+        run: |
+          set -euo pipefail
+
+          echo "Triggering deployment of church-powerpoint"
+          RESP=$(curl -sS --fail-with-body \
+            -H "Authorization: Bearer $COOLIFY_TOKEN" \
+            "$COOLIFY_BASE/deploy?uuid=$APP_UUID&force=false")
+
+          DU=$(echo "$RESP" | jq -r '.deployments[0].deployment_uuid // empty')
+          if [ -z "$DU" ]; then
+            echo "::error::Coolify did not queue a deployment. Response: $RESP"
+            exit 1
+          fi
+          echo "deployment_uuid=$DU"
+
+          # Rust images build from scratch each time (no cargo cache layer), so
+          # allow well over twenty minutes before giving up.
+          for i in $(seq 1 160); do
+            sleep 10
+            ST=$(curl -sS -H "Authorization: Bearer $COOLIFY_TOKEN" \
+                  "$COOLIFY_BASE/deployments/$DU" | jq -r '.status // "unknown"')
+            echo "[$((i * 10))s] status=$ST"
+            case "$ST" in
+              finished)
+                echo "::notice::Deployed church-powerpoint successfully"
+                exit 0 ;;
+              failed|cancelled-by-user)
+                echo "::error::Deployment ended as '$ST'. Check the Coolify dashboard at https://homeserver.tail724b7f.ts.net"
+                exit 1 ;;
+            esac
+          done
+
+          echo "::error::Timed out waiting for the deployment to finish"
+          exit 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tower = { version = "0.5", features = ["limit", "timeout", "util"] }
 tower-http = { version = "0.6", features = ["fs", "trace", "limit"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 tower = { version = "0.5", features = ["limit", "timeout", "util"] }
 tower-http = { version = "0.6", features = ["fs", "trace", "limit"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,52 @@ confession, the assurance of forgiveness, the Lord's Prayer, the creed — is fi
 in automatically. Pressing Generate produces a `.pptx` built from the
 TWPC-branded template, ready to open and project.
 
+## Editor and generation behaviour
+
+The editor autosaves without rebuilding the whole page on every keystroke. Counts
+and validation are batched, component fields keep their focus while staff type,
+and drag-and-drop ordering avoids unnecessary DOM work. Psalm, scripture and
+teaching lookups are read-only until the corresponding Load button is pressed;
+the app may prefetch them when a staff member focuses or points at that action so
+the explicit load feels faster. Shared prefetched requests still retain the
+normal ten-second loader timeout.
+
+The song picker loads the complete matching set into a bounded, scrollable list.
+There is no hidden fourteen-song result limit.
+
+Psalm body text is authored at 32pt. Automatic Psalm pagination greedily keeps
+whole source stanzas together according to the available rendered height. Two
+typical stanzas are the design target, but three or more short stanzas may share
+a slide when they fit. A stanza rolls intact to the next slide when adding it
+would overflow; an individually oversized stanza is kept whole so no text is
+silently lost. Staff-edited slide breaks remain authoritative.
+
+### Background deck preparation
+
+After an autosave has remained unchanged for 3.5 seconds, the server may prepare
+the exact saved revision in the background. This is an optimisation only:
+
+- preparation runs on one dedicated worker and uses a bounded queue;
+- completed decks are cached in memory for up to 20 minutes, with a maximum of
+  four decks or 64 MiB;
+- cache identity includes the service ID and revision, global settings version,
+  and embedded-template generation;
+- a later edit or settings change invalidates the corresponding prepared work;
+- preparation never marks a service complete, publishes a deck, or writes to
+  generated history;
+- Generate briefly checks for the exact prepared result, then falls back to the
+  normal foreground build instead of waiting behind the background queue.
+
+Successful generation still performs all permanent writes in one place: it
+stores the PPTX, records an immutable service snapshot in generated history, and
+marks the live service complete. The response header `x-deck-preparation` is
+`hit` when prepared bytes were reused and `miss` when a foreground build was
+needed.
+
+From the Generated PowerPoints page, **Use as starting point** restores the
+immutable settings saved with that generated revision into a new draft. It does
+not modify the original service or its generated history.
+
 ## Running it
 
 The server needs a few things from the environment:
@@ -39,10 +85,12 @@ cargo test --workspace        # Rust: unit tests and HTTP endpoint tests
 npm test                      # frontend: vitest under jsdom
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
+bash scripts/validate-openxml.sh  # representative deck + Microsoft Open XML SDK
 ```
 
-The last two are enforced by CI; `npm test` is not, so run it locally when you
-touch anything in `crates/server/static/`.
+Formatting and Clippy are enforced by CI. `npm test` is not, so run it locally
+when you touch anything in `crates/server/static/`. Run the Open XML validator
+whenever presentation generation or package structure changes.
 
 **Static assets and JSON data are compiled into the binary** with `include_str!`
 and `include_bytes!`. Editing a file under `crates/server/static/`,
@@ -77,7 +125,12 @@ reachable master must be registered, and each master must own its theme part.
 Real PowerPoint is the only trustworthy check that a generated deck opens. If you
 are changing anything in `pptx-template`, read
 [`docs/powerpoint-repair-postmortem.md`](docs/powerpoint-repair-postmortem.md)
-first.
+first. For presentation-generation changes, validate a representative deck with
+`scripts/validate-openxml.sh` and, where PowerPoint is available, open it there
+and inspect representative dense slides as the final smoke test. Running Office
+inside Docker is not the expected workflow; the Open XML SDK container provides
+schema validation, while a licensed desktop PowerPoint installation remains the
+application-level check.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,14 @@ silently lost. Staff-edited slide breaks remain authoritative.
 
 ### Background deck preparation
 
-After an autosave has remained unchanged for 3.5 seconds, the server may prepare
-the exact saved revision in the background. This is an optimisation only:
+Full-deck background preparation is experimental and disabled by default. It was
+found to compete with foreground Generate on CPU-constrained hosting, because
+PPTX assembly and ZIP compression are CPU-heavy. Safe read-only source
+prefetching remains enabled, but production uses the original single foreground
+deck build unless `BACKGROUND_DECK_PREPARATION=true` is explicitly configured.
+
+When explicitly enabled, an autosave that remains unchanged for 3.5 seconds may
+prepare the exact saved revision in the background:
 
 - preparation runs on one dedicated worker and uses a bounded queue;
 - completed decks are cached in memory for up to 20 minutes, with a maximum of
@@ -44,8 +50,9 @@ the exact saved revision in the background. This is an optimisation only:
 - a later edit or settings change invalidates the corresponding prepared work;
 - preparation never marks a service complete, publishes a deck, or writes to
   generated history;
-- Generate briefly checks for the exact prepared result, then falls back to the
-  normal foreground build instead of waiting behind the background queue.
+- Generate uses an exact result only when it is already complete. It never waits
+  behind the background queue; otherwise it immediately uses the normal
+  foreground build.
 
 Successful generation still performs all permanent writes in one place: it
 stores the PPTX, records an immutable service snapshot in generated history, and
@@ -70,6 +77,7 @@ The server needs a few things from the environment:
 | `PORT` | Defaults to 8080 |
 | `OBJECT_STORE` | Set to `memory` to run without R2; nothing is persisted |
 | `COOKIE_SECURE` | Set to `false` when developing over plain HTTP |
+| `BACKGROUND_DECK_PREPARATION` | Experimental full-deck preparation; defaults to `false` because it can compete for CPU on constrained hosts |
 
 ```sh
 cargo run -p server

--- a/crates/deck-builder/src/lib.rs
+++ b/crates/deck-builder/src/lib.rs
@@ -289,7 +289,13 @@ pub async fn build_deck(
                     set_shape_text(&mut pres, slide, "TextShape 1", title)?;
                     let runs = psalm_runs(&stanza, *show_verse_numbers);
                     set_shape_runs(&mut pres, slide, "TextShape 2", &runs)?;
-                    hide_logo_when_text_reaches_it(&mut pres, slide, "TextShape 2", &runs, 2800)?;
+                    hide_logo_when_text_reaches_it(
+                        &mut pres,
+                        slide,
+                        "TextShape 2",
+                        &runs,
+                        PSALM_FONT_SIZE_HUNDREDTHS_PT,
+                    )?;
                     if index + 1 == count {
                         pres.copy_shape(SEED_SONG_FINAL, "TextBox 4", slide, "Psalm Credits")?;
                         pres.slide_mut(slide)?
@@ -527,17 +533,17 @@ pub fn propose_psalm_groups(stanzas: &[String]) -> Vec<String> {
     let mut current_lines = 0;
     for stanza in stanzas {
         let stanza_lines = estimated_psalm_lines(stanza, characters_per_line);
-        let separator_lines = usize::from(!current.is_empty());
-        if !current.is_empty() && current_lines + separator_lines + stanza_lines > max_lines {
+        if !current.is_empty() && current_lines + 1 + stanza_lines > max_lines {
             groups.push(current);
             current = String::new();
             current_lines = 0;
         }
         if !current.is_empty() {
             current.push_str("\n\n");
+            current_lines += 1;
         }
         current.push_str(stanza);
-        current_lines += separator_lines + stanza_lines;
+        current_lines += stanza_lines;
     }
     if !current.is_empty() {
         groups.push(current);
@@ -546,14 +552,14 @@ pub fn propose_psalm_groups(stanzas: &[String]) -> Vec<String> {
 }
 
 // TextShape 2 in the Psalm seed is 9,683,583 × 4,506,298 EMU. Generated
-// runs use 28pt Arial Black, with 100% paragraph line spacing. These limits
+// runs use 32pt Arial Black, with 100% paragraph line spacing. These limits
 // are derived from that box rather than from an arbitrary stanza count. The
 // 50% average glyph-width and 85/90% safety factors leave room for wide words,
 // verse markers, and PowerPoint's font metrics while still grouping ordinary
 // three- or four-line Psalm paragraphs.
 const PSALM_TEXT_BOX_WIDTH_EMU: u64 = 9_683_583;
 const PSALM_TEXT_BOX_HEIGHT_EMU: u64 = 4_506_298;
-const PSALM_FONT_SIZE_HUNDREDTHS_PT: u64 = 2_800;
+const PSALM_FONT_SIZE_HUNDREDTHS_PT: u32 = 3_200;
 const EMU_PER_POINT: u64 = 12_700;
 const PSALM_AVERAGE_GLYPH_WIDTH_PERCENT: u64 = 50;
 const PSALM_VERTICAL_SAFETY_PERCENT: u64 = 85;
@@ -612,7 +618,7 @@ fn estimated_runs_height_emu(runs: &[Run], shape_width_emu: u64, default_font_si
 }
 
 fn psalm_layout_capacity() -> (usize, usize) {
-    let font_height_emu = PSALM_FONT_SIZE_HUNDREDTHS_PT * EMU_PER_POINT / 100;
+    let font_height_emu = u64::from(PSALM_FONT_SIZE_HUNDREDTHS_PT) * EMU_PER_POINT / 100;
     let natural_lines = PSALM_TEXT_BOX_HEIGHT_EMU / font_height_emu;
     let max_lines = (natural_lines * PSALM_VERTICAL_SAFETY_PERCENT / 100).max(1) as usize;
 
@@ -853,7 +859,7 @@ fn psalm_runs(text: &str, show_verse_numbers: bool) -> Vec<Run> {
         };
         let Some(index) = next else {
             let mut run = Run::plain(remaining)
-                .with_font_size(2800)
+                .with_font_size(PSALM_FONT_SIZE_HUNDREDTHS_PT)
                 .with_text_style("Arial Black", "000000");
             run.underline = underlined;
             marked.push(run);
@@ -861,7 +867,7 @@ fn psalm_runs(text: &str, show_verse_numbers: bool) -> Vec<Run> {
         };
         if index > 0 {
             let mut run = Run::plain(&remaining[..index])
-                .with_font_size(2800)
+                .with_font_size(PSALM_FONT_SIZE_HUNDREDTHS_PT)
                 .with_text_style("Arial Black", "000000");
             run.underline = underlined;
             marked.push(run);
@@ -884,7 +890,7 @@ fn psalm_runs(text: &str, show_verse_numbers: bool) -> Vec<Run> {
             let is_superscript = superscript.is_some();
             if current_superscript.is_some_and(|value| value != is_superscript) {
                 let mut split = Run::plain(std::mem::take(&mut current))
-                    .with_font_size(2800)
+                    .with_font_size(PSALM_FONT_SIZE_HUNDREDTHS_PT)
                     .with_text_style("Arial Black", "000000");
                 split.underline = run.underline;
                 split.superscript = current_superscript.unwrap_or(false);
@@ -895,7 +901,7 @@ fn psalm_runs(text: &str, show_verse_numbers: bool) -> Vec<Run> {
         }
         if !current.is_empty() {
             let mut split = Run::plain(current)
-                .with_font_size(2800)
+                .with_font_size(PSALM_FONT_SIZE_HUNDREDTHS_PT)
                 .with_text_style("Arial Black", "000000");
             split.underline = run.underline;
             split.superscript = current_superscript.unwrap_or(false);
@@ -1256,8 +1262,38 @@ mod tests {
     }
 
     #[test]
+    fn psalm_grouping_allows_more_than_two_short_stanzas_when_they_fit() {
+        let stanzas = vec![
+            "first".to_string(),
+            "second".to_string(),
+            "third".to_string(),
+            "fourth".to_string(),
+        ];
+
+        let pages = propose_psalm_groups(&stanzas);
+
+        assert_eq!(pages, vec![stanzas.join("\n\n")]);
+    }
+
+    #[test]
+    fn psalm_grouping_rolls_a_whole_stanza_when_the_pair_does_not_fit() {
+        let first = (1..=5)
+            .map(|line| format!("first stanza line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let second = (1..=5)
+            .map(|line| format!("second stanza line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let pages = propose_psalm_groups(&[first.clone(), second.clone()]);
+
+        assert_eq!(pages, vec![first, second]);
+    }
+
+    #[test]
     fn psalm_grouping_never_splits_an_oversized_stanza() {
-        let oversized = (1..=9)
+        let oversized = (1..=10)
             .map(|line| format!("line {line}"))
             .collect::<Vec<_>>()
             .join("\n");
@@ -1269,11 +1305,16 @@ mod tests {
     }
 
     #[test]
-    fn psalm_23_uses_readable_two_stanza_groups() {
+    fn psalm_23_rolls_stanzas_according_to_32pt_capacity() {
         let psalm = Psalm::find("Psalm 23:1-6").expect("Psalm 23 exists");
         let pages = propose_psalm_groups(&psalm.stanzas);
 
-        assert_eq!(pages.len(), 3);
+        assert_eq!(pages.len(), 4);
+        assert_eq!(pages.join("\n\n"), psalm.stanzas.join("\n\n"));
+        assert_eq!(
+            pages[3],
+            format!("{}\n\n{}", psalm.stanzas[3], psalm.stanzas[4])
+        );
         assert!(pages.iter().all(|page| page.lines().count() <= 7));
     }
 
@@ -1284,7 +1325,7 @@ mod tests {
             true,
         );
         assert!(runs.iter().all(
-            |run| run.font_size == Some(2800) && run.typeface.as_deref() == Some("Arial Black")
+            |run| run.font_size == Some(3200) && run.typeface.as_deref() == Some("Arial Black")
         ));
         assert!(runs.iter().any(|run| run.superscript && run.text == "4"));
         assert!(runs

--- a/crates/deck-builder/tests/build_deck.rs
+++ b/crates/deck-builder/tests/build_deck.rs
@@ -224,6 +224,9 @@ async fn generated_psalm_runs_specify_arial_black_for_all_script_ranges() {
     let first_psalm_slide = pres.slide_xml(0).expect("first Psalm slide XML");
     let first_psalm_body = named_shape_xml(&first_psalm_slide, "TextShape 2");
 
+    assert!(first_psalm_body.contains("sz=\"3200\""));
+    assert!(!first_psalm_body.contains("sz=\"2800\""));
+
     for script in ["latin", "ea", "cs"] {
         assert!(
             first_psalm_body.contains(&format!("<a:{script} typeface=\"Arial Black\"/>")),
@@ -431,8 +434,9 @@ async fn generated_content_keeps_template_hierarchy_and_safe_sizing() {
     assert!(amen.contains("<a:schemeClr val=\"accent1\"/>") && amen.contains("b=\"1\""));
 
     let psalm = xml.iter().find(|slide| slide.contains("seven")).unwrap();
-    assert!(psalm.contains("sz=\"2800\""));
-    assert!(!psalm.contains("sz=\"3200\"") && !psalm.contains("sz=\"2600\""));
+    let psalm_body = named_shape_xml(psalm, "TextShape 2");
+    assert!(psalm_body.contains("sz=\"3200\""));
+    assert!(!psalm_body.contains("sz=\"2800\"") && !psalm_body.contains("sz=\"2600\""));
     assert!(psalm.contains("typeface=\"Arial Black\""));
     assert!(psalm.contains("<a:off x=\"6724800\" y=\"6080400\"/>"));
     let teaching = xml

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -25,9 +25,11 @@ use serde_json::json;
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use store::{MemoryObjectStore, ObjectStore, PutCondition, StoreError, StoredObject};
+use tokio::sync::watch;
 
 pub(crate) const PPTX_CONTENT_TYPE: &str =
     "application/vnd.openxmlformats-officedocument.presentationml.presentation";
@@ -36,6 +38,14 @@ const JSON_CONTENT_TYPE: &str = "application/json";
 const LOGIN_WINDOW: Duration = Duration::from_secs(15 * 60);
 const LOGIN_ATTEMPTS: usize = 8;
 const GENERATED_DECK_RETENTION_DAYS: i64 = 730;
+const PREPARED_DECK_TTL: Duration = Duration::from_secs(20 * 60);
+const PREPARED_DECK_LIMIT: usize = 4;
+const PREPARED_DECK_BYTE_LIMIT: usize = 64 * 1024 * 1024;
+const PREPARE_QUEUE_LIMIT: usize = 4;
+const PREPARED_DECK_JOIN_GRACE: Duration = Duration::from_millis(350);
+// The template is embedded in the process. Bump this if a future deployment can swap templates
+// without restarting, so bytes produced under the old template can never be reused.
+const TEMPLATE_GENERATION: u32 = 1;
 
 #[derive(Clone)]
 pub struct AppConfig {
@@ -76,6 +86,138 @@ pub(crate) struct AppState {
     config: AppConfig,
     login_limiter: Arc<Mutex<HashMap<String, Vec<Instant>>>>,
     next_id: Arc<AtomicU64>,
+    prepared_decks: Arc<Mutex<PreparedDeckCache>>,
+    prepare_tx: SyncSender<PrepareJob>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct PreparedDeckKey {
+    service_id: String,
+    service_revision: u64,
+    settings_version: u64,
+    template_generation: u32,
+}
+
+impl PreparedDeckKey {
+    fn new(service: &ServiceRecord, settings: &GlobalSettingsVersion) -> Self {
+        Self {
+            service_id: service.id.clone(),
+            service_revision: service.revision,
+            settings_version: settings.version,
+            template_generation: TEMPLATE_GENERATION,
+        }
+    }
+}
+
+#[derive(Clone)]
+enum PreparationOutcome {
+    Building,
+    Ready(Arc<[u8]>),
+    Failed,
+}
+
+struct PreparedDeckEntry {
+    bytes: Arc<[u8]>,
+    created_at: Instant,
+}
+
+#[derive(Default)]
+struct PreparedDeckCache {
+    ready: HashMap<PreparedDeckKey, PreparedDeckEntry>,
+    in_flight: HashMap<PreparedDeckKey, watch::Receiver<PreparationOutcome>>,
+    latest_for_service: HashMap<String, PreparedDeckKey>,
+    total_bytes: usize,
+}
+
+impl PreparedDeckCache {
+    fn prune(&mut self, now: Instant) {
+        let expired = self
+            .ready
+            .iter()
+            .filter(|(_, entry)| {
+                now.saturating_duration_since(entry.created_at) > PREPARED_DECK_TTL
+            })
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        for key in expired {
+            self.remove_ready(&key);
+        }
+    }
+
+    fn get_ready(&mut self, key: &PreparedDeckKey) -> Option<Arc<[u8]>> {
+        self.prune(Instant::now());
+        self.ready.get(key).map(|entry| entry.bytes.clone())
+    }
+
+    fn insert_ready(&mut self, key: PreparedDeckKey, bytes: Arc<[u8]>) {
+        self.prune(Instant::now());
+        let older_for_service = self
+            .ready
+            .keys()
+            .filter(|candidate| candidate.service_id == key.service_id && **candidate != key)
+            .cloned()
+            .collect::<Vec<_>>();
+        for candidate in older_for_service {
+            self.remove_ready(&candidate);
+        }
+        if bytes.len() > PREPARED_DECK_BYTE_LIMIT {
+            return;
+        }
+        if let Some(previous) = self.ready.remove(&key) {
+            self.total_bytes = self.total_bytes.saturating_sub(previous.bytes.len());
+        }
+        while self.ready.len() >= PREPARED_DECK_LIMIT
+            || self.total_bytes.saturating_add(bytes.len()) > PREPARED_DECK_BYTE_LIMIT
+        {
+            let Some(oldest) = self
+                .ready
+                .iter()
+                .min_by_key(|(_, entry)| entry.created_at)
+                .map(|(candidate, _)| candidate.clone())
+            else {
+                break;
+            };
+            self.remove_ready(&oldest);
+        }
+        self.total_bytes = self.total_bytes.saturating_add(bytes.len());
+        self.ready.insert(
+            key,
+            PreparedDeckEntry {
+                bytes,
+                created_at: Instant::now(),
+            },
+        );
+    }
+
+    fn remove_ready(&mut self, key: &PreparedDeckKey) {
+        if let Some(entry) = self.ready.remove(key) {
+            self.total_bytes = self.total_bytes.saturating_sub(entry.bytes.len());
+        }
+    }
+
+    fn is_latest(&self, key: &PreparedDeckKey) -> bool {
+        self.latest_for_service.get(&key.service_id) == Some(key)
+    }
+
+    fn finish(&mut self, key: &PreparedDeckKey) {
+        self.in_flight.remove(key);
+        if self.latest_for_service.get(&key.service_id) == Some(key) {
+            self.latest_for_service.remove(&key.service_id);
+        }
+    }
+}
+
+struct PrepareJob {
+    key: PreparedDeckKey,
+    service: ServiceRecord,
+    settings: GlobalSettingsVersion,
+    outcome: watch::Sender<PreparationOutcome>,
+}
+
+struct PreparationWorkerState {
+    sources: Arc<dyn Sources>,
+    store: Arc<dyn ObjectStore>,
+    prepared_decks: Arc<Mutex<PreparedDeckCache>>,
 }
 
 struct ServiceSources {
@@ -107,13 +249,26 @@ impl Sources for ServiceSources {
 }
 
 pub fn app(sources: Arc<dyn Sources>, store: Arc<dyn ObjectStore>, config: AppConfig) -> Router {
+    let prepared_decks = Arc::new(Mutex::new(PreparedDeckCache::default()));
+    let (prepare_tx, prepare_rx) = mpsc::sync_channel(PREPARE_QUEUE_LIMIT);
     let state = AppState {
         sources,
         store,
         config,
         login_limiter: Arc::new(Mutex::new(HashMap::new())),
         next_id: Arc::new(AtomicU64::new(1)),
+        prepared_decks,
+        prepare_tx,
     };
+    let worker_state = PreparationWorkerState {
+        sources: state.sources.clone(),
+        store: state.store.clone(),
+        prepared_decks: state.prepared_decks.clone(),
+    };
+    std::thread::Builder::new()
+        .name("deck-preparation".to_string())
+        .spawn(move || prepare_worker(worker_state, prepare_rx))
+        .expect("could not start background deck preparation worker");
 
     let protected = Router::new()
         .route("/", get(builder_page))
@@ -139,6 +294,7 @@ pub fn app(sources: Arc<dyn Sources>, store: Arc<dyn ObjectStore>, config: AppCo
         )
         .route("/api/services/:id/restore", post(restore_service))
         .route("/api/services/:id/autosave", put(update_service))
+        .route("/api/services/:id/prepare", post(prepare_service))
         .route("/api/services/:id/generate", post(generate_service))
         .route("/api/services/:id/history", get(service_history))
         .route("/api/generated", get(generated_decks))
@@ -526,6 +682,11 @@ async fn list_services(
 ) -> Result<Json<Vec<ServiceRecord>>, AppError> {
     let mut services = Vec::new();
     for key in state.store.list("entities/services/").await? {
+        // The same prefix also contains every generated revision. Fetching those one by one from
+        // R2 only to fail ServiceRecord deserialization made builder startup slower over time.
+        if !is_current_service_key(&key) {
+            continue;
+        }
         if let Ok(object) = state.store.get(&key).await {
             if let Ok(service) = serde_json::from_slice::<ServiceRecord>(&object.bytes) {
                 services.push(service);
@@ -574,6 +735,7 @@ async fn update_service(
         PutCondition::IfMatch(object.etag),
     )
     .await?;
+    invalidate_prepared_service(&state, &id);
     json_with_etag(StatusCode::OK, &incoming, &stored.etag)
 }
 
@@ -609,7 +771,255 @@ async fn change_service_status(
         PutCondition::IfMatch(object.etag),
     )
     .await?;
+    invalidate_prepared_service(state, id);
     Ok(Json(service))
+}
+
+#[derive(Deserialize)]
+struct PrepareDeckRequest {
+    revision: u64,
+}
+
+#[derive(Serialize)]
+struct PrepareDeckResponse {
+    status: &'static str,
+    revision: u64,
+}
+
+async fn prepare_service(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(request): Json<PrepareDeckRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let (service, _) = load_service(&state, &id).await?;
+    if request.revision != service.revision {
+        return Err(AppError::conflict(
+            "this service changed before background preparation could begin",
+        ));
+    }
+    let settings = load_settings(&state).await?;
+    let key = PreparedDeckKey::new(&service, &settings);
+    let (outcome, receiver) = watch::channel(PreparationOutcome::Building);
+
+    let previous_latest = {
+        let mut cache = prepared_cache(&state.prepared_decks)?;
+        if cache.get_ready(&key).is_some() {
+            return Ok((
+                StatusCode::OK,
+                Json(PrepareDeckResponse {
+                    status: "ready",
+                    revision: request.revision,
+                }),
+            ));
+        }
+        if cache.in_flight.contains_key(&key) {
+            return Ok((
+                StatusCode::ACCEPTED,
+                Json(PrepareDeckResponse {
+                    status: "preparing",
+                    revision: request.revision,
+                }),
+            ));
+        }
+        cache.in_flight.insert(key.clone(), receiver);
+        cache
+            .latest_for_service
+            .insert(key.service_id.clone(), key.clone())
+    };
+
+    let job = PrepareJob {
+        key: key.clone(),
+        service,
+        settings,
+        outcome,
+    };
+    if state.prepare_tx.try_send(job).is_err() {
+        let mut cache = prepared_cache(&state.prepared_decks)?;
+        cache.in_flight.remove(&key);
+        if cache.latest_for_service.get(&key.service_id) == Some(&key) {
+            match previous_latest {
+                Some(previous) if cache.in_flight.contains_key(&previous) => {
+                    cache
+                        .latest_for_service
+                        .insert(key.service_id.clone(), previous);
+                }
+                _ => {
+                    cache.latest_for_service.remove(&key.service_id);
+                }
+            }
+        }
+        return Ok((
+            StatusCode::ACCEPTED,
+            Json(PrepareDeckResponse {
+                status: "busy",
+                revision: request.revision,
+            }),
+        ));
+    }
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(PrepareDeckResponse {
+            status: "preparing",
+            revision: request.revision,
+        }),
+    ))
+}
+
+fn prepare_worker(state: PreparationWorkerState, jobs: Receiver<PrepareJob>) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("could not start the deck preparation runtime");
+    while let Ok(job) = jobs.recv() {
+        runtime.block_on(process_prepare_job(&state, job));
+    }
+
+    // A closed worker means no queued receiver should leave a Generate request waiting forever.
+    if let Ok(mut cache) = prepared_cache(&state.prepared_decks) {
+        cache.in_flight.clear();
+        cache.latest_for_service.clear();
+    }
+}
+
+async fn process_prepare_job(state: &PreparationWorkerState, job: PrepareJob) {
+    let should_build = prepared_cache(&state.prepared_decks)
+        .map(|cache| cache.is_latest(&job.key))
+        .unwrap_or(false);
+    if !should_build {
+        let _ = job.outcome.send(PreparationOutcome::Failed);
+        if let Ok(mut cache) = prepared_cache(&state.prepared_decks) {
+            cache.finish(&job.key);
+        }
+        return;
+    }
+
+    let result =
+        render_service_deck(&state.sources, &state.store, &job.service, &job.settings).await;
+    let still_current = if result.is_ok() {
+        preparation_is_current(&state.store, &state.prepared_decks, &job.key).await
+    } else {
+        false
+    };
+
+    match result {
+        Ok(bytes) if still_current => {
+            let bytes = Arc::<[u8]>::from(bytes);
+            let _ = job.outcome.send(PreparationOutcome::Ready(bytes.clone()));
+            if let Ok(mut cache) = prepared_cache(&state.prepared_decks) {
+                if cache.is_latest(&job.key) {
+                    cache.insert_ready(job.key.clone(), bytes);
+                }
+                cache.finish(&job.key);
+            }
+        }
+        _ => {
+            let _ = job.outcome.send(PreparationOutcome::Failed);
+            if let Ok(mut cache) = prepared_cache(&state.prepared_decks) {
+                cache.finish(&job.key);
+            }
+        }
+    }
+}
+
+async fn preparation_is_current(
+    store: &Arc<dyn ObjectStore>,
+    prepared_decks: &Arc<Mutex<PreparedDeckCache>>,
+    key: &PreparedDeckKey,
+) -> bool {
+    let still_latest = prepared_cache(prepared_decks)
+        .map(|cache| cache.is_latest(key))
+        .unwrap_or(false);
+    if !still_latest {
+        return false;
+    }
+    let Ok(service_object) = store.get(&service_key(&key.service_id)).await else {
+        return false;
+    };
+    let Ok(service) = serde_json::from_slice::<ServiceRecord>(&service_object.bytes) else {
+        return false;
+    };
+    let Ok(settings_object) = store.get("entities/settings/current.json").await else {
+        return false;
+    };
+    let Ok(settings) = serde_json::from_slice::<GlobalSettingsVersion>(&settings_object.bytes)
+    else {
+        return false;
+    };
+    service.revision == key.service_revision && settings.version == key.settings_version
+}
+
+fn prepared_cache(
+    prepared_decks: &Arc<Mutex<PreparedDeckCache>>,
+) -> Result<std::sync::MutexGuard<'_, PreparedDeckCache>, AppError> {
+    prepared_decks
+        .lock()
+        .map_err(|_| AppError::internal("background deck cache became unavailable"))
+}
+
+fn invalidate_prepared_service(state: &AppState, id: &str) {
+    let Ok(mut cache) = prepared_cache(&state.prepared_decks) else {
+        return;
+    };
+    cache.latest_for_service.remove(id);
+    let ready = cache
+        .ready
+        .keys()
+        .filter(|key| key.service_id == id)
+        .cloned()
+        .collect::<Vec<_>>();
+    for key in ready {
+        cache.remove_ready(&key);
+    }
+}
+
+fn invalidate_all_prepared_decks(state: &AppState) {
+    let Ok(mut cache) = prepared_cache(&state.prepared_decks) else {
+        return;
+    };
+    cache.ready.clear();
+    cache.latest_for_service.clear();
+    cache.total_bytes = 0;
+}
+
+async fn render_service_deck(
+    upstream: &Arc<dyn Sources>,
+    store: &Arc<dyn ObjectStore>,
+    service: &ServiceRecord,
+    settings: &GlobalSettingsVersion,
+) -> Result<Vec<u8>, AppError> {
+    let sources = ServiceSources {
+        upstream: upstream.clone(),
+        store: store.clone(),
+    };
+    build_deck(service, &sources, &settings.ccli_licence_number)
+        .await
+        .map_err(|error| AppError::internal(format!("could not build service deck: {error}")))
+}
+
+async fn prepared_deck_for_generation(
+    state: &AppState,
+    key: &PreparedDeckKey,
+) -> Option<Arc<[u8]>> {
+    let mut receiver = {
+        let mut cache = prepared_cache(&state.prepared_decks).ok()?;
+        if let Some(bytes) = cache.get_ready(key) {
+            return Some(bytes);
+        }
+        cache.in_flight.get(key).cloned()
+    }?;
+
+    loop {
+        let outcome = receiver.borrow().clone();
+        match outcome {
+            PreparationOutcome::Building => {}
+            PreparationOutcome::Ready(bytes) => return Some(bytes),
+            PreparationOutcome::Failed => return None,
+        }
+        if receiver.changed().await.is_err() {
+            return None;
+        }
+    }
 }
 
 async fn generate_service(
@@ -619,13 +1029,22 @@ async fn generate_service(
 ) -> Result<Response, AppError> {
     let (mut service, object) = load_service(&state, &id).await?;
     let settings = load_settings(&state).await?;
-    let sources = ServiceSources {
-        upstream: state.sources.clone(),
-        store: state.store.clone(),
+    let cache_key = PreparedDeckKey::new(&service, &settings);
+    let prepared = tokio::time::timeout(
+        PREPARED_DECK_JOIN_GRACE,
+        prepared_deck_for_generation(&state, &cache_key),
+    )
+    .await
+    .ok()
+    .flatten();
+    let (bytes, preparation_status) = if let Some(prepared) = prepared {
+        (prepared.as_ref().to_vec(), "hit")
+    } else {
+        (
+            render_service_deck(&state.sources, &state.store, &service, &settings).await?,
+            "miss",
+        )
     };
-    let bytes = build_deck(&service, &sources, &settings.ccli_licence_number)
-        .await
-        .map_err(|error| AppError::internal(format!("could not build service deck: {error}")))?;
     let revision = state
         .store
         .list(&format!("generated/services/{id}/revisions/"))
@@ -685,6 +1104,10 @@ async fn generate_service(
             deck_filename(&service, revision)
         ))
         .map_err(|error| AppError::internal(error.to_string()))?,
+    );
+    response.headers_mut().insert(
+        "x-deck-preparation",
+        HeaderValue::from_static(preparation_status),
     );
     Ok(response)
 }
@@ -994,6 +1417,7 @@ async fn update_settings(
         PutCondition::IfMatch(object.etag),
     )
     .await?;
+    invalidate_all_prepared_decks(&state);
     Ok(Json(settings))
 }
 
@@ -1237,6 +1661,11 @@ fn service_key(id: &str) -> String {
     format!("entities/services/{id}.json")
 }
 
+fn is_current_service_key(key: &str) -> bool {
+    key.strip_prefix("entities/services/")
+        .is_some_and(|filename| !filename.contains('/') && filename.ends_with(".json"))
+}
+
 async fn load_service(
     state: &AppState,
     id: &str,
@@ -1328,5 +1757,54 @@ impl From<StoreError> for AppError {
             ),
             StoreError::Unavailable(message) => Self::internal(message),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        is_current_service_key, PreparedDeckCache, PreparedDeckEntry, PreparedDeckKey,
+        PREPARED_DECK_LIMIT, PREPARED_DECK_TTL, TEMPLATE_GENERATION,
+    };
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn service_listing_skips_generated_revision_metadata() {
+        assert!(is_current_service_key("entities/services/svc-123.json"));
+        assert!(!is_current_service_key(
+            "entities/services/svc-123/revisions/7.json"
+        ));
+        assert!(!is_current_service_key("entities/services/svc-123.pptx"));
+    }
+
+    #[test]
+    fn prepared_deck_cache_is_bounded_and_prunes_expired_entries() {
+        let mut cache = PreparedDeckCache::default();
+        for revision in 0..=PREPARED_DECK_LIMIT as u64 {
+            cache.insert_ready(
+                PreparedDeckKey {
+                    service_id: format!("service-{revision}"),
+                    service_revision: revision,
+                    settings_version: 1,
+                    template_generation: TEMPLATE_GENERATION,
+                },
+                Arc::<[u8]>::from(vec![revision as u8; 8]),
+            );
+        }
+        assert_eq!(cache.ready.len(), PREPARED_DECK_LIMIT);
+        assert_eq!(cache.total_bytes, PREPARED_DECK_LIMIT * 8);
+
+        let expired_key = cache.ready.keys().next().unwrap().clone();
+        cache.ready.insert(
+            expired_key.clone(),
+            PreparedDeckEntry {
+                bytes: Arc::<[u8]>::from(vec![0; 8]),
+                created_at: Instant::now() - PREPARED_DECK_TTL - Duration::from_secs(1),
+            },
+        );
+        assert!(cache.get_ready(&expired_key).is_none());
+        assert_eq!(cache.ready.len(), PREPARED_DECK_LIMIT - 1);
+        assert_eq!(cache.total_bytes, (PREPARED_DECK_LIMIT - 1) * 8);
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,9 +12,9 @@ use axum::routing::{get, post, put};
 use axum::{Extension, Json, Router};
 use chrono::{Duration as ChronoDuration, NaiveDate, Utc};
 use deck_builder::{
-    build_deck, propose_psalm_groups, FixedComponent, GeneratedDeckVersion, GlobalSettingsVersion,
-    Psalm, ServicePreset, ServiceRecord, ServiceStatus, Sources, StoredSong, Teaching,
-    TeachingSource,
+    build_deck, propose_psalm_groups, AuditMetadata, FixedComponent, GeneratedDeckVersion,
+    GlobalSettingsVersion, Psalm, ServicePreset, ServiceRecord, ServiceStatus, Sources, StoredSong,
+    Teaching, TeachingSource,
 };
 use hmac::{Hmac, Mac};
 use http::header::{ACCEPT, CONTENT_DISPOSITION, CONTENT_TYPE, COOKIE, ETAG, SET_COOKIE};
@@ -149,6 +149,10 @@ pub fn app(sources: Arc<dyn Sources>, store: Arc<dyn ObjectStore>, config: AppCo
         .route(
             "/api/services/:id/revisions/:revision/snapshot",
             get(service_revision_snapshot),
+        )
+        .route(
+            "/api/services/:id/revisions/:revision/restore",
+            post(restore_service_revision),
         )
         .route_layer(middleware::from_fn_with_state(state.clone(), require_staff))
         .with_state(state.clone());
@@ -718,6 +722,7 @@ struct GeneratedDeckListing {
     /// Decks generated before the service snapshot was recorded have nothing to show, and the
     /// history page hides the control rather than offering a link that cannot work.
     snapshot_url: Option<String>,
+    restore_url: Option<String>,
 }
 
 async fn generated_decks(
@@ -764,6 +769,12 @@ async fn generated_decks(
                     metadata.service_id, metadata.revision
                 )
             }),
+            restore_url: snapshot.map(|_| {
+                format!(
+                    "/api/services/{}/revisions/{}/restore",
+                    metadata.service_id, metadata.revision
+                )
+            }),
         });
     }
     generated.sort_by(|left, right| {
@@ -789,6 +800,46 @@ async fn service_revision_snapshot(
             "this PowerPoint was generated before the service was recorded with it",
         )
     })
+}
+
+/// Start a new editable service from the immutable settings saved with a generated deck. The
+/// original service and its history stay untouched, even if the live service has since changed.
+async fn restore_service_revision(
+    State(state): State<AppState>,
+    Extension(session): Extension<StaffSession>,
+    Path((id, revision)): Path<(String, u64)>,
+) -> Result<Response, AppError> {
+    let metadata = load_generated_deck(&state, &id, revision).await?;
+    let mut service = metadata.service.ok_or_else(|| {
+        AppError::new(
+            StatusCode::NOT_FOUND,
+            "this PowerPoint was generated before the service was recorded with it",
+        )
+    })?;
+
+    service.id = new_id(&state, "svc");
+    service.name = copy_service_name(&service.name);
+    service.status = ServiceStatus::Draft;
+    service.revision = 0;
+    service.audit = AuditMetadata::new(session.display_name);
+    validate_service_name(&service.name)?;
+
+    let stored = put_json(
+        state.store.as_ref(),
+        &service_key(&service.id),
+        &service,
+        PutCondition::IfNoneMatch,
+    )
+    .await?;
+    json_with_etag(StatusCode::CREATED, &service, &stored.etag)
+}
+
+fn copy_service_name(source: &str) -> String {
+    let mut name = format!("Copy of {source}");
+    while name.len() > 100 {
+        name.pop();
+    }
+    name
 }
 
 async fn load_generated_deck(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -23,13 +23,12 @@ use pptx_template::Presentation;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::Sha256;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use store::{MemoryObjectStore, ObjectStore, PutCondition, StoreError, StoredObject};
-use tokio::sync::watch;
 
 pub(crate) const PPTX_CONTENT_TYPE: &str =
     "application/vnd.openxmlformats-officedocument.presentationml.presentation";
@@ -42,7 +41,6 @@ const PREPARED_DECK_TTL: Duration = Duration::from_secs(20 * 60);
 const PREPARED_DECK_LIMIT: usize = 4;
 const PREPARED_DECK_BYTE_LIMIT: usize = 64 * 1024 * 1024;
 const PREPARE_QUEUE_LIMIT: usize = 4;
-const PREPARED_DECK_JOIN_GRACE: Duration = Duration::from_millis(350);
 // The template is embedded in the process. Bump this if a future deployment can swap templates
 // without restarting, so bytes produced under the old template can never be reused.
 const TEMPLATE_GENERATION: u32 = 1;
@@ -53,6 +51,7 @@ pub struct AppConfig {
     pub session_signing_secret: String,
     pub secure_cookies: bool,
     pub session_ttl: Duration,
+    pub background_deck_preparation: bool,
 }
 
 impl AppConfig {
@@ -75,6 +74,10 @@ impl AppConfig {
                 .map(|value| value != "false")
                 .unwrap_or(true),
             session_ttl: Duration::from_secs(8 * 60 * 60),
+            background_deck_preparation: matches!(
+                std::env::var("BACKGROUND_DECK_PREPARATION").as_deref(),
+                Ok("true" | "1")
+            ),
         })
     }
 }
@@ -88,6 +91,7 @@ pub(crate) struct AppState {
     next_id: Arc<AtomicU64>,
     prepared_decks: Arc<Mutex<PreparedDeckCache>>,
     prepare_tx: SyncSender<PrepareJob>,
+    background_deck_preparation: bool,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -109,13 +113,6 @@ impl PreparedDeckKey {
     }
 }
 
-#[derive(Clone)]
-enum PreparationOutcome {
-    Building,
-    Ready(Arc<[u8]>),
-    Failed,
-}
-
 struct PreparedDeckEntry {
     bytes: Arc<[u8]>,
     created_at: Instant,
@@ -124,7 +121,7 @@ struct PreparedDeckEntry {
 #[derive(Default)]
 struct PreparedDeckCache {
     ready: HashMap<PreparedDeckKey, PreparedDeckEntry>,
-    in_flight: HashMap<PreparedDeckKey, watch::Receiver<PreparationOutcome>>,
+    in_flight: HashSet<PreparedDeckKey>,
     latest_for_service: HashMap<String, PreparedDeckKey>,
     total_bytes: usize,
 }
@@ -211,7 +208,6 @@ struct PrepareJob {
     key: PreparedDeckKey,
     service: ServiceRecord,
     settings: GlobalSettingsVersion,
-    outcome: watch::Sender<PreparationOutcome>,
 }
 
 struct PreparationWorkerState {
@@ -251,6 +247,7 @@ impl Sources for ServiceSources {
 pub fn app(sources: Arc<dyn Sources>, store: Arc<dyn ObjectStore>, config: AppConfig) -> Router {
     let prepared_decks = Arc::new(Mutex::new(PreparedDeckCache::default()));
     let (prepare_tx, prepare_rx) = mpsc::sync_channel(PREPARE_QUEUE_LIMIT);
+    let background_deck_preparation = config.background_deck_preparation;
     let state = AppState {
         sources,
         store,
@@ -259,16 +256,19 @@ pub fn app(sources: Arc<dyn Sources>, store: Arc<dyn ObjectStore>, config: AppCo
         next_id: Arc::new(AtomicU64::new(1)),
         prepared_decks,
         prepare_tx,
+        background_deck_preparation,
     };
     let worker_state = PreparationWorkerState {
         sources: state.sources.clone(),
         store: state.store.clone(),
         prepared_decks: state.prepared_decks.clone(),
     };
-    std::thread::Builder::new()
-        .name("deck-preparation".to_string())
-        .spawn(move || prepare_worker(worker_state, prepare_rx))
-        .expect("could not start background deck preparation worker");
+    if background_deck_preparation {
+        std::thread::Builder::new()
+            .name("deck-preparation".to_string())
+            .spawn(move || prepare_worker(worker_state, prepare_rx))
+            .expect("could not start background deck preparation worker");
+    }
 
     let protected = Router::new()
         .route("/", get(builder_page))
@@ -791,6 +791,15 @@ async fn prepare_service(
     Path(id): Path<String>,
     Json(request): Json<PrepareDeckRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    if !state.background_deck_preparation {
+        return Ok((
+            StatusCode::OK,
+            Json(PrepareDeckResponse {
+                status: "disabled",
+                revision: request.revision,
+            }),
+        ));
+    }
     let (service, _) = load_service(&state, &id).await?;
     if request.revision != service.revision {
         return Err(AppError::conflict(
@@ -799,8 +808,6 @@ async fn prepare_service(
     }
     let settings = load_settings(&state).await?;
     let key = PreparedDeckKey::new(&service, &settings);
-    let (outcome, receiver) = watch::channel(PreparationOutcome::Building);
-
     let previous_latest = {
         let mut cache = prepared_cache(&state.prepared_decks)?;
         if cache.get_ready(&key).is_some() {
@@ -812,7 +819,7 @@ async fn prepare_service(
                 }),
             ));
         }
-        if cache.in_flight.contains_key(&key) {
+        if cache.in_flight.contains(&key) {
             return Ok((
                 StatusCode::ACCEPTED,
                 Json(PrepareDeckResponse {
@@ -821,7 +828,7 @@ async fn prepare_service(
                 }),
             ));
         }
-        cache.in_flight.insert(key.clone(), receiver);
+        cache.in_flight.insert(key.clone());
         cache
             .latest_for_service
             .insert(key.service_id.clone(), key.clone())
@@ -831,14 +838,13 @@ async fn prepare_service(
         key: key.clone(),
         service,
         settings,
-        outcome,
     };
     if state.prepare_tx.try_send(job).is_err() {
         let mut cache = prepared_cache(&state.prepared_decks)?;
         cache.in_flight.remove(&key);
         if cache.latest_for_service.get(&key.service_id) == Some(&key) {
             match previous_latest {
-                Some(previous) if cache.in_flight.contains_key(&previous) => {
+                Some(previous) if cache.in_flight.contains(&previous) => {
                     cache
                         .latest_for_service
                         .insert(key.service_id.clone(), previous);
@@ -887,7 +893,6 @@ async fn process_prepare_job(state: &PreparationWorkerState, job: PrepareJob) {
         .map(|cache| cache.is_latest(&job.key))
         .unwrap_or(false);
     if !should_build {
-        let _ = job.outcome.send(PreparationOutcome::Failed);
         if let Ok(mut cache) = prepared_cache(&state.prepared_decks) {
             cache.finish(&job.key);
         }
@@ -905,7 +910,6 @@ async fn process_prepare_job(state: &PreparationWorkerState, job: PrepareJob) {
     match result {
         Ok(bytes) if still_current => {
             let bytes = Arc::<[u8]>::from(bytes);
-            let _ = job.outcome.send(PreparationOutcome::Ready(bytes.clone()));
             if let Ok(mut cache) = prepared_cache(&state.prepared_decks) {
                 if cache.is_latest(&job.key) {
                     cache.insert_ready(job.key.clone(), bytes);
@@ -914,7 +918,6 @@ async fn process_prepare_job(state: &PreparationWorkerState, job: PrepareJob) {
             }
         }
         _ => {
-            let _ = job.outcome.send(PreparationOutcome::Failed);
             if let Ok(mut cache) = prepared_cache(&state.prepared_decks) {
                 cache.finish(&job.key);
             }
@@ -997,29 +1000,16 @@ async fn render_service_deck(
         .map_err(|error| AppError::internal(format!("could not build service deck: {error}")))
 }
 
-async fn prepared_deck_for_generation(
-    state: &AppState,
-    key: &PreparedDeckKey,
-) -> Option<Arc<[u8]>> {
-    let mut receiver = {
-        let mut cache = prepared_cache(&state.prepared_decks).ok()?;
-        if let Some(bytes) = cache.get_ready(key) {
-            return Some(bytes);
-        }
-        cache.in_flight.get(key).cloned()
-    }?;
-
-    loop {
-        let outcome = receiver.borrow().clone();
-        match outcome {
-            PreparationOutcome::Building => {}
-            PreparationOutcome::Ready(bytes) => return Some(bytes),
-            PreparationOutcome::Failed => return None,
-        }
-        if receiver.changed().await.is_err() {
-            return None;
-        }
+fn prepared_deck_for_generation(state: &AppState, key: &PreparedDeckKey) -> Option<Arc<[u8]>> {
+    let mut cache = prepared_cache(&state.prepared_decks).ok()?;
+    let ready = cache.get_ready(key);
+    if ready.is_none() && cache.latest_for_service.get(&key.service_id) == Some(key) {
+        // Prevent a queued speculative job from starting after foreground generation begins.
+        // An already-running build cannot be interrupted safely, which is why this feature is
+        // disabled by default on constrained hosts.
+        cache.latest_for_service.remove(&key.service_id);
     }
+    ready
 }
 
 async fn generate_service(
@@ -1030,13 +1020,7 @@ async fn generate_service(
     let (mut service, object) = load_service(&state, &id).await?;
     let settings = load_settings(&state).await?;
     let cache_key = PreparedDeckKey::new(&service, &settings);
-    let prepared = tokio::time::timeout(
-        PREPARED_DECK_JOIN_GRACE,
-        prepared_deck_for_generation(&state, &cache_key),
-    )
-    .await
-    .ok()
-    .flatten();
+    let prepared = prepared_deck_for_generation(&state, &cache_key);
     let (bytes, preparation_status) = if let Some(prepared) = prepared {
         (prepared.as_ref().to_vec(), "hit")
     } else {

--- a/crates/server/static/app.css
+++ b/crates/server/static/app.css
@@ -329,7 +329,7 @@ input:focus, select:focus, textarea:focus { border-color: var(--focus); outline:
 .selected-song { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 11px 12px; border: 1px solid #b9cec2; border-radius: var(--radius-sm); background: var(--success-soft); }
 .selected-song strong, .selected-song small { display: block; }
 .selected-song small { margin-top: 2px; color: var(--ink-soft); }
-.song-picker-results { display: grid; max-height: 330px; overflow-y: auto; border-radius: var(--radius-sm); background: var(--surface); }
+  .song-picker-results { display: grid; max-height: 330px; overflow-y: auto; overscroll-behavior: contain; scrollbar-gutter: stable; border-radius: var(--radius-sm); background: var(--surface); }
 .song-choice { display: flex; width: 100%; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 11px; border: 0; border-bottom: 1px solid var(--line); background: transparent; color: var(--ink); text-align: left; }
 .song-choice:first-child { border-radius: var(--radius-sm) var(--radius-sm) 0 0; }
 .song-choice:last-child { border-bottom: 0; border-radius: 0 0 var(--radius-sm) var(--radius-sm); }

--- a/crates/server/static/app.js
+++ b/crates/server/static/app.js
@@ -776,7 +776,10 @@ export function createEditorApp({
       request('/api/services').then(response => response.json()),
     ]).then(([loadedPresets, services]) => {
       presets = loadedPresets; renderPresetChoices();
-      const current = services.find(item => item.status === 'draft') || services.find(item => item.status !== 'archived');
+      const requestedServiceId = new URLSearchParams(locationImpl?.search || '').get('service');
+      const current = services.find(item => item.id === requestedServiceId)
+        || services.find(item => item.status === 'draft')
+        || services.find(item => item.status !== 'archived');
       if (current) loadService(current); else ui['new-dialog']?.showModal();
     }).catch(error => showToast(error.message));
   }

--- a/crates/server/static/app.js
+++ b/crates/server/static/app.js
@@ -13,6 +13,80 @@ const DEFAULT_TIMERS = {
   clearInterval: globalThis.clearInterval.bind(globalThis),
 };
 
+export function createGetRequestCache(request, {
+  ttlMs = 5 * 60 * 1_000,
+  maxEntries = 64,
+  now = () => Date.now(),
+} = {}) {
+  const entries = new Map();
+
+  function remove(url, entry) {
+    if (entries.get(url) === entry) entries.delete(url);
+  }
+
+  function prune() {
+    const currentTime = now();
+    for (const [url, entry] of entries) {
+      if (entry.expiresAt <= currentTime) entries.delete(url);
+    }
+    while (entries.size >= Math.max(1, maxEntries)) {
+      entries.delete(entries.keys().next().value);
+    }
+  }
+
+  function responseForConsumer(promise, signal) {
+    if (!signal) return promise.then(response => response.clone());
+    if (signal.aborted) {
+      const error = new Error('The request was aborted.');
+      error.name = 'AbortError';
+      return Promise.reject(error);
+    }
+    return new Promise((resolve, reject) => {
+      const abort = () => {
+        const error = new Error('The request was aborted.');
+        error.name = 'AbortError';
+        reject(error);
+      };
+      signal.addEventListener('abort', abort, { once: true });
+      promise.then(response => {
+        signal.removeEventListener('abort', abort);
+        resolve(response.clone());
+      }, error => {
+        signal.removeEventListener('abort', abort);
+        reject(error);
+      });
+    });
+  }
+
+  function get(url, { signal } = {}) {
+    const existing = entries.get(url);
+    if (existing && existing.expiresAt > now()) {
+      return responseForConsumer(existing.promise, signal);
+    }
+    if (existing) entries.delete(url);
+    prune();
+    const entry = { expiresAt: Number.POSITIVE_INFINITY, promise: null };
+    entry.promise = Promise.resolve()
+      .then(() => request(url))
+      .then(response => {
+        if (response.ok) entry.expiresAt = now() + ttlMs;
+        else remove(url, entry);
+        return response;
+      }, error => {
+        remove(url, entry);
+        throw error;
+      });
+    entries.set(url, entry);
+    return responseForConsumer(entry.promise, signal);
+  }
+
+  function prefetch(url) {
+    return get(url).then(() => undefined).catch(() => undefined);
+  }
+
+  return { get, prefetch };
+}
+
 export function createEditorApp({
   document: doc = globalThis.document,
   request: injectedRequest,
@@ -20,6 +94,11 @@ export function createEditorApp({
   timers = DEFAULT_TIMERS,
   confirmImpl = globalThis.confirm?.bind(globalThis) || (() => true),
   locationImpl = doc.defaultView?.location,
+  scheduleFrame = callback => {
+    const frame = doc.defaultView?.requestAnimationFrame;
+    if (frame) return frame.call(doc.defaultView, callback);
+    return globalThis.queueMicrotask(callback);
+  },
 } = {}) {
   const ui = Object.fromEntries([
     'service-name', 'service-date', 'service-preset', 'service-heading', 'crumb-name',
@@ -35,6 +114,10 @@ export function createEditorApp({
   let toastTimer = null;
   let booted = false;
   let generationPromise = null;
+  let derivedRenderPending = false;
+  let draggedOrderItem = null;
+  let lastOrderDragTarget = null;
+  let lastOrderDragBefore = null;
   const generationLabels = new Map();
 
   async function request(url, options = {}) {
@@ -54,6 +137,17 @@ export function createEditorApp({
     return response;
   }
 
+  const getRequests = createGetRequestCache(url => request(url));
+
+  function prefetchOnIntent(element, urlForCurrentState) {
+    const prefetch = () => {
+      const url = urlForCurrentState();
+      if (url) void getRequests.prefetch(url);
+    };
+    element.addEventListener('pointerenter', prefetch);
+    element.addEventListener('focus', prefetch);
+  }
+
   function today() {
     const date = new Date();
     date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
@@ -71,8 +165,13 @@ export function createEditorApp({
   function setSaveState(kind, message) {
     if (!ui['save-state']) return;
     const stateClass = { Unsaved: 'saving', Saving: 'saving', Saved: '', Failed: 'error' }[kind] || '';
-    ui['save-state'].className = `save-state ${stateClass}`;
+    const className = `save-state ${stateClass}`;
+    if (ui['save-state'].dataset.state === kind
+      && ui['save-state'].className === className
+      && ui['save-state'].textContent === kind) return;
+    ui['save-state'].className = className;
     ui['save-state'].replaceChildren(doc.createElement('span'), doc.createTextNode(kind));
+    ui['save-state'].dataset.state = kind;
   }
 
   function setSaveHelp(message) {
@@ -131,11 +230,24 @@ export function createEditorApp({
 
   function renderAll() {
     if (!controller.getService()) return;
+    // A full render already refreshes the derived panels. Any queued frame can become a no-op.
+    derivedRenderPending = false;
     renderServiceFields();
     renderOrder();
     renderEditor();
     updateCounts();
     renderValidation();
+  }
+
+  function scheduleDerivedRender() {
+    if (derivedRenderPending) return;
+    derivedRenderPending = true;
+    scheduleFrame(() => {
+      if (!derivedRenderPending) return;
+      derivedRenderPending = false;
+      updateCounts();
+      renderValidation();
+    });
   }
 
   function renderOrder() {
@@ -175,14 +287,30 @@ export function createEditorApp({
       actions.append(duplicate, remove);
       item.append(handle, main, actions);
 
-      item.addEventListener('dragstart', () => item.classList.add('dragging'));
-      item.addEventListener('dragend', () => item.classList.remove('dragging'));
+      item.addEventListener('dragstart', () => {
+        draggedOrderItem = item;
+        lastOrderDragTarget = null;
+        lastOrderDragBefore = null;
+        item.classList.add('dragging');
+      });
+      item.addEventListener('dragend', () => {
+        item.classList.remove('dragging');
+        draggedOrderItem = null;
+        lastOrderDragTarget = null;
+        lastOrderDragBefore = null;
+      });
       item.addEventListener('dragover', event => {
         event.preventDefault();
-        const dragging = ui['component-list'].querySelector('.dragging');
-        if (dragging && dragging !== item) {
+        if (draggedOrderItem && draggedOrderItem !== item) {
           const box = item.getBoundingClientRect();
-          ui['component-list'].insertBefore(dragging, event.clientY < box.top + box.height / 2 ? item : item.nextSibling);
+          const before = event.clientY < box.top + box.height / 2;
+          if (lastOrderDragTarget === item && lastOrderDragBefore === before) return;
+          lastOrderDragTarget = item;
+          lastOrderDragBefore = before;
+          const anchor = before ? item : item.nextSibling;
+          if (anchor !== draggedOrderItem && draggedOrderItem.nextSibling !== anchor) {
+            ui['component-list'].insertBefore(draggedOrderItem, anchor);
+          }
         }
       });
       ui['component-list'].append(item);
@@ -200,14 +328,23 @@ export function createEditorApp({
 
   function syncDraggedOrder() {
     const order = [...ui['component-list'].children].map(item => item.dataset.id);
+    const positions = new Map(order.map((id, index) => [id, index]));
+    draggedOrderItem = null;
+    lastOrderDragTarget = null;
+    lastOrderDragBefore = null;
     controller.updateService(service => {
-      service.components.sort((a, b) => order.indexOf(a.id) - order.indexOf(b.id));
+      service.components.sort((a, b) => positions.get(a.id) - positions.get(b.id));
     }, 'structural');
   }
 
   function selectComponent(id) {
+    const previousId = controller.getState().selectedId;
+    if (previousId === id) return;
     controller.selectComponent(id);
-    renderOrder();
+    for (const item of ui['component-list']?.children || []) {
+      if (item.dataset.id === previousId) item.classList.remove('selected');
+      if (item.dataset.id === id) item.classList.add('selected');
+    }
     renderEditor();
     const panel = ui['editor-panel'];
     if (panel) {
@@ -230,21 +367,19 @@ export function createEditorApp({
   function duplicateComponent(index) {
     const copy = structuredClone(controller.getService().components[index]);
     copy.id = `component-${Date.now().toString(36)}`;
+    controller.selectComponent(copy.id);
     controller.updateService(service => {
       service.components.splice(index + 1, 0, copy);
     }, 'structural');
-    controller.selectComponent(copy.id);
-    renderAll();
   }
 
   function removeComponent(index) {
     const service = controller.getService();
     const removed = service.components[index];
-    controller.updateService(current => { current.components.splice(index, 1); }, 'structural');
     if (removed.id === controller.getState().selectedId) {
-      controller.selectComponent(service.components[index]?.id || service.components[index - 1]?.id || null);
-      renderAll();
+      controller.selectComponent(service.components[index + 1]?.id || service.components[index - 1]?.id || null);
     }
+    controller.updateService(current => { current.components.splice(index, 1); }, 'structural');
   }
 
   function renderEditor() {
@@ -365,6 +500,12 @@ export function createEditorApp({
       if (!/\d/.test(reference)) { showToast('Enter a complete Bible reference, for example Psalm 23:1–6.'); return; }
       void controller.loadEsv(componentId, reference);
     });
+    prefetchOnIntent(fetchButton, () => {
+      const reference = controller.findComponent(componentId)?.reference || '';
+      return /\d/.test(reference)
+        ? `/api/scripture?reference=${encodeURIComponent(reference)}`
+        : null;
+    });
     inline.append(fetchButton, error); fields.append(inline);
     fields.append(textArea('Editable wording', component.id, 'text', component.text, 'Manual entry remains available if the ESV request fails.'));
   }
@@ -400,11 +541,11 @@ export function createEditorApp({
       const currentSequence = ++sequence;
       status.textContent = 'Searching library…'; searchInput.setAttribute('aria-expanded', 'true');
       try {
-        const response = await request(`/api/songs?q=${encodeURIComponent(searchInput.value.trim())}`);
+        const response = await getRequests.get(`/api/songs?q=${encodeURIComponent(searchInput.value.trim())}`);
         const songs = await response.json();
         if (currentSequence !== sequence) return;
         results.replaceChildren();
-        songs.slice(0, 14).forEach(song => {
+        songs.forEach(song => {
           const choice = button('', 'song-choice'); choice.setAttribute('role', 'option');
           const copy = doc.createElement('span');
           const title = doc.createElement('strong'); title.textContent = song.title;
@@ -417,7 +558,7 @@ export function createEditorApp({
           }, 'structural'));
           results.append(choice);
         });
-        status.textContent = songs.length ? `${songs.length} match${songs.length === 1 ? '' : 'es'}${songs.length > 14 ? ', showing the first 14' : ''}.` : 'No matching songs. Try a shorter title or an alternative spelling.';
+        status.textContent = songs.length ? `${songs.length} match${songs.length === 1 ? '' : 'es'}.` : 'No matching songs. Try a shorter title or an alternative spelling.';
         searchInput.setAttribute('aria-expanded', songs.length ? 'true' : 'false');
       } catch (error) {
         results.replaceChildren(); status.textContent = 'The song library could not be loaded.'; searchInput.setAttribute('aria-expanded', 'false'); showToast(error.message);
@@ -425,6 +566,7 @@ export function createEditorApp({
     }
     searchInput.addEventListener('focus', () => { if (!results.children.length) searchSongs(); });
     searchInput.addEventListener('input', () => { if (timer !== null) timers.clearTimeout(timer); timer = timers.setTimeout(searchSongs, 260); });
+    void getRequests.prefetch('/api/songs?q=');
 
     if (!component.song) {
       const divider = doc.createElement('div'); divider.className = 'editor-divider'; divider.textContent = 'Or enter custom lyrics'; fields.append(divider);
@@ -464,6 +606,12 @@ export function createEditorApp({
       if (!/\d/.test(reference)) { showToast('Enter a complete Psalm reference, for example Psalm 23:1–6.'); return; }
       void controller.loadPsalm(componentId, reference);
     });
+    prefetchOnIntent(loadButton, () => {
+      const reference = controller.findComponent(componentId)?.reference || '';
+      return /\d/.test(reference)
+        ? `/api/psalm?reference=${encodeURIComponent(reference)}`
+        : null;
+    });
     inline.append(loadButton, error); fields.append(inline);
     renderSlideBlocks(fields, component.id, 'slide_breaks', 'Psalm slide');
     const note = doc.createElement('p'); note.className = 'field-note'; note.textContent = 'Loading proposes readable groups from the embedded Sing Psalms text. You can then edit every break before generation.'; fields.append(note);
@@ -502,6 +650,12 @@ export function createEditorApp({
         return;
       }
       void controller.loadTeaching(component.id, current.source, current.selection);
+    });
+    prefetchOnIntent(loadButton, () => {
+      const current = controller.findComponent(component.id);
+      return current?.selection.trim()
+        ? `/api/teaching?source=${encodeURIComponent(current.source)}&selection=${encodeURIComponent(current.selection)}`
+        : null;
     });
     inline.append(loadButton, error); fields.append(inline);
     const note = doc.createElement('p'); note.className = 'field-note';
@@ -602,6 +756,7 @@ export function createEditorApp({
     if (controller.isDirty() || controller.isSaving()) {
       try {
         await controller.saveNow();
+        controller.cancelPreparation();
       } catch (error) {
         const generation = controller.getState().editGeneration;
         if (!confirmImpl(`Generation ${generation} is not saved. Leave and discard local edits?`)) return;
@@ -681,6 +836,7 @@ export function createEditorApp({
     generationPromise = (async () => {
       try {
         await controller.saveNow();
+        controller.cancelPreparation();
         setSaveState('Saving', 'Generating PowerPoint…');
         const response = await request(`/api/services/${service.id}/generate`, { method: 'POST' });
         const blob = await response.blob();
@@ -749,7 +905,8 @@ export function createEditorApp({
     ui['save-now']?.addEventListener('click', () => controller.saveNow().catch(() => {}));
     ui['add-component']?.addEventListener('click', () => {
       const component = { type: 'custom_text_image', id: `component-${Date.now().toString(36)}`, heading: 'Custom slide', slides: [''], image: null };
-      controller.updateService(service => { service.components.push(component); }, 'structural'); controller.selectComponent(component.id); renderOrder(); renderEditor();
+      controller.selectComponent(component.id);
+      controller.updateService(service => { service.components.push(component); }, 'structural');
     });
     ui['sign-out']?.addEventListener('click', () => {
       void guardedLeave(async () => {
@@ -765,8 +922,8 @@ export function createEditorApp({
     ui['service-preset']?.addEventListener('change', () => {
       const service = controller.getService(); const preset = presets.find(item => item.id === ui['service-preset'].value);
       if (!preset || !confirmImpl('Replace the current order with this preset?')) { ui['service-preset'].value = service.preset; return; }
+      controller.selectComponent(preset.components[0]?.id || null);
       controller.updateService(current => { current.preset = preset.id; current.components = structuredClone(preset.components); }, 'structural');
-      controller.selectComponent(controller.getService().components[0]?.id || null); renderAll();
     });
     doc.defaultView?.addEventListener('beforeunload', event => {
       if (controller.isDirty() || controller.isSaving()) { event.preventDefault(); event.returnValue = ''; }
@@ -790,8 +947,9 @@ export function createEditorApp({
 
   controller = createEditorController({
     request,
+    cachedGet: getRequests.get,
     timers,
-    render: { all: renderAll, order: renderOrder, editor: renderEditor, validation: renderValidation, orderItem: updateOrderItem, counts: updateCounts, heading: updateHeading, loader: renderLoaderState },
+    render: { all: renderAll, order: renderOrder, editor: renderEditor, derived: scheduleDerivedRender, validation: renderValidation, orderItem: updateOrderItem, counts: updateCounts, heading: updateHeading, loader: renderLoaderState },
     setSaveState,
     setSaveHelp,
     showToast,

--- a/crates/server/static/editor-controller.js
+++ b/crates/server/static/editor-controller.js
@@ -20,6 +20,7 @@ export function createEditorController({
     saveTimer: null,
     prepareTimer: null,
     prepareEpoch: 0,
+    preparationAvailable: true,
     activeSave: null,
     transition: Promise.resolve(),
     transitionDepth: 0,
@@ -344,6 +345,7 @@ export function createEditorController({
   }
 
   function schedulePreparation(serviceId, revision, generation) {
+    if (!state.preparationAvailable) return;
     cancelPreparation();
     const epoch = state.prepareEpoch;
     state.prepareTimer = timers.setTimeout(() => {
@@ -357,7 +359,12 @@ export function createEditorController({
       void checkedRequest(`/api/services/${encodeURIComponent(serviceId)}/prepare`, {
         method: 'POST',
         body: JSON.stringify({ revision }),
-      }).catch(() => {});
+      })
+        .then(response => response.json().catch(() => ({})))
+        .then(result => {
+          if (result.status === 'disabled') state.preparationAvailable = false;
+        })
+        .catch(() => {});
     }, PREPARE_IDLE_MS);
   }
 

--- a/crates/server/static/editor-controller.js
+++ b/crates/server/static/editor-controller.js
@@ -1,8 +1,10 @@
 export const SAVE_DEBOUNCE_MS = 900;
 export const LOADER_TIMEOUT_MS = 10_000;
+export const PREPARE_IDLE_MS = 3_500;
 
 export function createEditorController({
   request,
+  cachedGet = null,
   timers = { setTimeout, clearTimeout },
   makeAbortController = () => new AbortController(),
   render = {},
@@ -16,6 +18,8 @@ export function createEditorController({
     editGeneration: 0,
     savedGeneration: 0,
     saveTimer: null,
+    prepareTimer: null,
+    prepareEpoch: 0,
     activeSave: null,
     transition: Promise.resolve(),
     transitionDepth: 0,
@@ -46,6 +50,16 @@ export function createEditorController({
     throw error;
   }
 
+  async function checkedGet(url, options = {}) {
+    const response = cachedGet ? await cachedGet(url, options) : await request(url, options);
+    if (response.ok) return response;
+    const data = await response.json().catch(() => ({}));
+    const error = new Error(data.error || `Request failed (${response.status})`);
+    error.status = response.status;
+    error.body = data;
+    throw error;
+  }
+
   function loaderKey(kind, componentId) {
     return `${kind}:${componentId}`;
   }
@@ -66,7 +80,8 @@ export function createEditorController({
       timers.clearTimeout(timeoutId);
     }, LOADER_TIMEOUT_MS);
     try {
-      const response = await checkedRequest(url, { signal: abortController.signal });
+      const response = await checkedGet(url, { signal: abortController.signal });
+      if (timedOut) throw new Error('The request timed out after 10 seconds. Retry.');
       const data = await response.json();
       const parsed = parseSuccess(data);
       const current = findComponent(componentId);
@@ -169,19 +184,16 @@ export function createEditorController({
     } else if (scope === 'heading') {
       (render.heading || noop)();
       (render.orderItem || noop)(state.selectedId);
-      (render.validation || noop)();
+      (render.derived || noop)();
     } else if (scope === 'loader') {
       (render.editor || noop)();
       (render.orderItem || noop)(state.selectedId);
-      (render.counts || noop)();
-      (render.validation || noop)();
+      (render.derived || noop)();
     } else if (scope === 'summary') {
       (render.orderItem || noop)(state.selectedId);
-      (render.counts || noop)();
-      (render.validation || noop)();
+      (render.derived || noop)();
     } else {
-      (render.counts || noop)();
-      (render.validation || noop)();
+      (render.derived || noop)();
     }
   }
 
@@ -195,6 +207,7 @@ export function createEditorController({
 
   function markDirty(scope = 'targeted') {
     if (scope === 'structural') invalidateLoaderSequences();
+    cancelPreparation();
     state.editGeneration += 1;
     state.status = state.activeSave ? 'Saving' : 'Unsaved';
     setSaveState(state.status, state.status);
@@ -226,6 +239,7 @@ export function createEditorController({
   }
 
   function loadService(record, { discardUnsaved = false } = {}) {
+    cancelPreparation();
     return enqueueTransition(async () => {
       if (discardUnsaved) {
         clearPendingTimer();
@@ -265,6 +279,7 @@ export function createEditorController({
         state.status = 'Saved';
         setSaveState('Saved', 'Saved');
         setSaveHelp('');
+        schedulePreparation(state.service.id, saved.revision, sentGeneration);
       } else {
         state.status = 'Unsaved';
         setSaveState('Unsaved', 'Unsaved');
@@ -322,6 +337,30 @@ export function createEditorController({
     state.saveTimer = null;
   }
 
+  function cancelPreparation() {
+    state.prepareEpoch += 1;
+    if (state.prepareTimer !== null) timers.clearTimeout(state.prepareTimer);
+    state.prepareTimer = null;
+  }
+
+  function schedulePreparation(serviceId, revision, generation) {
+    cancelPreparation();
+    const epoch = state.prepareEpoch;
+    state.prepareTimer = timers.setTimeout(() => {
+      state.prepareTimer = null;
+      if (state.prepareEpoch !== epoch
+        || state.service?.id !== serviceId
+        || state.service?.revision !== revision
+        || state.editGeneration !== generation
+        || state.savedGeneration !== generation
+        || state.conflict) return;
+      void checkedRequest(`/api/services/${encodeURIComponent(serviceId)}/prepare`, {
+        method: 'POST',
+        body: JSON.stringify({ revision }),
+      }).catch(() => {});
+    }, PREPARE_IDLE_MS);
+  }
+
   function saveNow() {
     if (state.transitionDepth === 0) return flushDirtyGenerations({ retryActiveFailure: true });
     return enqueueTransition(() => flushDirtyGenerations({ retryActiveFailure: true }));
@@ -347,6 +386,7 @@ export function createEditorController({
     flushPendingSave,
     isDirty,
     isSaving,
+    cancelPreparation,
     loadPsalm,
     loadEsv,
     loadTeaching,

--- a/crates/server/static/generated.js
+++ b/crates/server/static/generated.js
@@ -42,6 +42,26 @@ async function downloadDeck(record, button) {
   }
 }
 
+// Restoring creates a separate draft. The generated revision remains an immutable record of
+// what was originally handed out, while the new service can be freely edited in the builder.
+async function restoreDeck(record, button) {
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = 'Opening builder…';
+  try {
+    const response = await request(record.restore_url, { method: 'POST' });
+    const service = await response.json();
+    const link = document.createElement('a');
+    link.href = `/?service=${encodeURIComponent(service.id)}`;
+    link.click();
+  } catch (error) {
+    showToast(error.message);
+  } finally {
+    button.disabled = false;
+    button.textContent = original;
+  }
+}
+
 function componentSummary(component) {
   const detail = [
     component.reference,
@@ -135,6 +155,15 @@ function render(records) {
       contents.setAttribute('aria-expanded', 'false');
       contents.addEventListener('click', () => toggleSnapshot(record, contents, panel));
       actions.append(contents);
+    }
+
+    if (record.restore_url) {
+      const restore = document.createElement('button');
+      restore.type = 'button';
+      restore.className = 'button button-secondary';
+      restore.textContent = 'Use as starting point';
+      restore.addEventListener('click', () => restoreDeck(record, restore));
+      actions.append(restore);
     }
 
     const download = document.createElement('button');

--- a/crates/server/templates/generated.html
+++ b/crates/server/templates/generated.html
@@ -34,7 +34,7 @@
       </header>
       <section class="page-content generated-page" aria-labelledby="generated-heading">
         <div class="page-heading">
-          <div><h2 id="generated-heading">Generated service decks</h2><p>Download every retained PowerPoint revision, newest first.</p></div>
+          <div><h2 id="generated-heading">Generated service decks</h2><p>Download a retained PowerPoint or use its saved settings as the starting point for a new service.</p></div>
           <p class="record-count" id="generated-count" aria-live="polite">Loading files…</p>
         </div>
         <div id="generated-results" class="generated-results" aria-live="polite" aria-busy="true">

--- a/crates/server/tests/endpoints.rs
+++ b/crates/server/tests/endpoints.rs
@@ -23,7 +23,7 @@ impl Sources for TestSources {
     }
 }
 
-fn test_app() -> axum::Router {
+fn test_app_with_background(background_deck_preparation: bool) -> axum::Router {
     let salt = SaltString::encode_b64(b"twpc-test-salt").unwrap();
     let hash = Argon2::default()
         .hash_password(b"correct horse", &salt)
@@ -36,12 +36,23 @@ fn test_app() -> axum::Router {
             session_signing_secret: "test-session-signing-secret-at-least-32-bytes".into(),
             secure_cookies: false,
             session_ttl: Duration::from_secs(3600),
+            background_deck_preparation,
         },
     )
 }
 
+fn test_app() -> axum::Router {
+    test_app_with_background(false)
+}
+
 async fn authenticated() -> (axum::Router, String, String) {
     let app = test_app();
+    let (cookie, csrf) = login(&app, "Test Staff").await;
+    (app, cookie, csrf)
+}
+
+async fn authenticated_with_background() -> (axum::Router, String, String) {
+    let app = test_app_with_background(true);
     let (cookie, csrf) = login(&app, "Test Staff").await;
     (app, cookie, csrf)
 }
@@ -617,8 +628,34 @@ async fn generates_an_immutable_revision_without_locking() {
 }
 
 #[tokio::test]
-async fn prepares_an_exact_revision_without_creating_history_and_generation_reuses_it() {
+async fn full_deck_background_preparation_is_disabled_by_default() {
     let (app, cookie, csrf) = authenticated().await;
+    let id = create_service(&app, &cookie, &csrf, "Foreground generation").await;
+    let service = get_json(&app, &cookie, &format!("/api/services/{id}")).await;
+    let revision = service["revision"].as_u64().unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/services/{id}/prepare"))
+                .header("cookie", cookie)
+                .header("x-csrf-token", csrf)
+                .header("content-type", "application/json")
+                .body(Body::from(format!(r#"{{"revision":{revision}}}"#)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body["status"], "disabled");
+}
+
+#[tokio::test]
+async fn prepares_an_exact_revision_without_creating_history_and_generation_reuses_it() {
+    let (app, cookie, csrf) = authenticated_with_background().await;
     let created = app
         .clone()
         .oneshot(

--- a/crates/server/tests/endpoints.rs
+++ b/crates/server/tests/endpoints.rs
@@ -630,6 +630,10 @@ async fn generated_history_records_the_service_each_deck_was_built_from() {
         snapshot_url,
         format!("/api/services/{id}/revisions/1/snapshot")
     );
+    assert_eq!(
+        listing[0]["restore_url"].as_str().expect("restore url"),
+        format!("/api/services/{id}/revisions/1/restore")
+    );
 
     let snapshot = get_json(&app, &cookie, snapshot_url).await;
     assert_eq!(snapshot["id"], id.as_str());
@@ -671,6 +675,85 @@ async fn generated_history_records_the_service_each_deck_was_built_from() {
     assert_eq!(
         listing[0]["service_name"], "Morning service",
         "history shows the name the deck was generated under"
+    );
+}
+
+/// Reusing a generated deck must fork the saved settings into a new draft. It must never turn
+/// the historical snapshot back into the live service or overwrite later edits to that service.
+#[tokio::test]
+async fn generated_service_settings_can_be_restored_as_a_new_draft() {
+    let (app, cookie, csrf) = authenticated().await;
+    let id = create_service(&app, &cookie, &csrf, "Morning service").await;
+    generate(&app, &cookie, &csrf, &id).await;
+
+    let snapshot_url = format!("/api/services/{id}/revisions/1/snapshot");
+    let snapshot = get_json(&app, &cookie, &snapshot_url).await;
+
+    // Prove restoration uses the immutable generated revision, not the live service that may
+    // since have been renamed and rearranged.
+    let mut live = get_json(&app, &cookie, &format!("/api/services/{id}")).await;
+    live["name"] = serde_json::json!("Renamed live service");
+    live["components"].as_array_mut().unwrap().reverse();
+    let updated = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/services/{id}"))
+                .header("cookie", &cookie)
+                .header("x-csrf-token", &csrf)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&live).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.status(), StatusCode::OK);
+
+    let restored_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/services/{id}/revisions/1/restore"))
+                .header("cookie", &cookie)
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(restored_response.status(), StatusCode::CREATED);
+    let body = to_bytes(restored_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let restored: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let restored_id = restored["id"].as_str().expect("new service id");
+    assert_ne!(restored_id, id);
+    assert_eq!(restored["name"], "Copy of Morning service");
+    assert_eq!(restored["date"], snapshot["date"]);
+    assert_eq!(restored["preset"], snapshot["preset"]);
+    assert_eq!(restored["period"], snapshot["period"]);
+    assert_eq!(restored["pm_style"], snapshot["pm_style"]);
+    assert_eq!(restored["lords_supper"], snapshot["lords_supper"]);
+    assert_eq!(restored["components"], snapshot["components"]);
+    assert_eq!(restored["status"], "draft");
+    assert_eq!(restored["revision"], 0);
+    assert_eq!(restored["audit"]["created_by"], "Test Staff");
+
+    let source = get_json(&app, &cookie, &format!("/api/services/{id}")).await;
+    assert_eq!(source["name"], "Renamed live service");
+    assert_ne!(source["components"], restored["components"]);
+    assert_eq!(
+        get_json(&app, &cookie, &snapshot_url).await["components"],
+        snapshot["components"],
+        "restoring must not rewrite the generated revision"
+    );
+    assert_eq!(
+        get_json(&app, &cookie, &format!("/api/services/{restored_id}")).await["components"],
+        snapshot["components"],
+        "the restored draft is persisted and opens like any other service"
     );
 }
 

--- a/crates/server/tests/endpoints.rs
+++ b/crates/server/tests/endpoints.rs
@@ -616,6 +616,122 @@ async fn generates_an_immutable_revision_without_locking() {
     Presentation::open_bytes(&body).unwrap().validate().unwrap();
 }
 
+#[tokio::test]
+async fn prepares_an_exact_revision_without_creating_history_and_generation_reuses_it() {
+    let (app, cookie, csrf) = authenticated().await;
+    let created = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/services")
+                .header("cookie", &cookie)
+                .header("x-csrf-token", &csrf)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"name":"Prepared service","date":"2026-07-12","preset":"am"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = to_bytes(created.into_body(), usize::MAX).await.unwrap();
+    let service: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let id = service["id"].as_str().unwrap();
+    let revision = service["revision"].as_u64().unwrap();
+
+    let stale = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/services/{id}/prepare"))
+                .header("cookie", &cookie)
+                .header("x-csrf-token", &csrf)
+                .header("content-type", "application/json")
+                .body(Body::from(format!(r#"{{"revision":{}}}"#, revision + 1)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stale.status(), StatusCode::CONFLICT);
+
+    let prepared = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/services/{id}/prepare"))
+                .header("cookie", &cookie)
+                .header("x-csrf-token", &csrf)
+                .header("content-type", "application/json")
+                .body(Body::from(format!(r#"{{"revision":{revision}}}"#)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(prepared.status(), StatusCode::ACCEPTED);
+
+    let mut became_ready = false;
+    for _ in 0..400 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let status = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/services/{id}/prepare"))
+                    .header("cookie", &cookie)
+                    .header("x-csrf-token", &csrf)
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(r#"{{"revision":{revision}}}"#)))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status();
+        if status == StatusCode::OK {
+            became_ready = true;
+            break;
+        }
+        assert_eq!(status, StatusCode::ACCEPTED);
+    }
+    assert!(became_ready, "background deck preparation did not finish");
+
+    let history = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/services/{id}/history"))
+                .header("cookie", &cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let history = to_bytes(history.into_body(), usize::MAX).await.unwrap();
+    let history: serde_json::Value = serde_json::from_slice(&history).unwrap();
+    assert_eq!(history, serde_json::json!([]));
+
+    let generated = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/services/{id}/generate"))
+                .header("cookie", &cookie)
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(generated.status(), StatusCode::OK);
+    assert_eq!(generated.headers()["x-deck-preparation"], "hit");
+    let body = to_bytes(generated.into_body(), usize::MAX).await.unwrap();
+    Presentation::open_bytes(&body).unwrap().validate().unwrap();
+}
+
 /// The live service keeps being edited after a deck is handed out, so the history has to keep
 /// its own copy of what each PowerPoint was built from.
 #[tokio::test]

--- a/render.yaml
+++ b/render.yaml
@@ -19,3 +19,6 @@ services:
         sync: false
       - key: R2_SECRET_ACCESS_KEY
         sync: false
+      # Full PPTX assembly is CPU-heavy and competes with foreground Generate on this plan.
+      - key: BACKGROUND_DECK_PREPARATION
+        value: "false"

--- a/tests/editor-controller.test.js
+++ b/tests/editor-controller.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createEditorController, SAVE_DEBOUNCE_MS } from '../crates/server/static/editor-controller.js';
+import { createEditorController, PREPARE_IDLE_MS, SAVE_DEBOUNCE_MS } from '../crates/server/static/editor-controller.js';
 import { deferred, jsonResponse, makeService } from './helpers/editor-fixture.js';
 
 function controllerWithFetch(fetchRequest, overrides = {}) {
@@ -16,6 +16,58 @@ function controllerWithFetch(fetchRequest, overrides = {}) {
 }
 
 describe('editor controller seam', () => {
+  it('prepares only the exact revision left idle after a successful autosave', async () => {
+    const service = makeService();
+    const callbacks = [];
+    const requests = [];
+    const timers = {
+      setTimeout: vi.fn((callback, delay) => {
+        callbacks.push({ callback, delay });
+        return callbacks.length;
+      }),
+      clearTimeout: vi.fn(),
+    };
+    const controller = controllerWithFetch(async (url, options = {}) => {
+      requests.push({ url, options });
+      if (url.endsWith('/autosave')) return jsonResponse({ ...service, revision: 5 });
+      if (url.endsWith('/prepare')) return jsonResponse({ status: 'preparing', revision: 5 }, { status: 202 });
+      throw new Error(`unexpected request to ${url}`);
+    }, { timers });
+
+    await controller.loadService(service);
+    controller.updateComponent('reading-1', component => { component.reference = 'John 3:16'; });
+    await controller.saveNow();
+
+    const scheduled = callbacks.find(timer => timer.delay === PREPARE_IDLE_MS);
+    expect(scheduled).toBeDefined();
+    expect(controller.getState()).toMatchObject({ status: 'Saved', editGeneration: 1, savedGeneration: 1 });
+    scheduled.callback();
+    await vi.waitFor(() => expect(requests.some(({ url }) => url.endsWith('/prepare'))).toBe(true));
+    const prepare = requests.find(({ url }) => url.endsWith('/prepare'));
+    expect(prepare).toEqual({
+      url: '/api/services/service-1/prepare',
+      options: { method: 'POST', body: JSON.stringify({ revision: 5 }) },
+    });
+
+    controller.updateComponent('reading-1', component => { component.reference = 'John 3:17'; });
+    scheduled.callback();
+    await Promise.resolve();
+    expect(requests.filter(({ url }) => url.endsWith('/prepare'))).toHaveLength(1);
+  });
+
+  it('does not schedule preparation after a failed autosave', async () => {
+    const service = makeService();
+    const timers = { setTimeout: vi.fn(() => 1), clearTimeout: vi.fn() };
+    const controller = controllerWithFetch(
+      async () => new Response(JSON.stringify({ error: 'offline' }), { status: 503 }),
+      { timers },
+    );
+    await controller.loadService(service);
+    controller.updateComponent('reading-1', component => { component.reference = 'John 3:16'; });
+    await expect(controller.saveNow()).rejects.toThrow('offline');
+    expect(timers.setTimeout.mock.calls.some(([, delay]) => delay === PREPARE_IDLE_MS)).toBe(false);
+  });
+
   it('exposes canonical service state and generation counters', () => {
     const controller = createEditorController({
       request: async () => jsonResponse({}),

--- a/tests/editor-rendering.test.js
+++ b/tests/editor-rendering.test.js
@@ -302,6 +302,24 @@ describe('editor render boundaries', () => {
     expect(beforeunload.defaultPrevented).toBe(true);
   });
 
+  it('opens the service requested by a restore link instead of another existing draft', async () => {
+    const firstDraft = makeService({ id: 'older-draft', name: 'Older draft' });
+    const restored = makeService({ id: 'restored-draft', name: 'Copy of Morning service' });
+    const app = createEditorApp({
+      document,
+      locationImpl: { search: '?service=restored-draft', assign: vi.fn() },
+      request: async url => {
+        if (url === '/api/presets') return jsonResponse([]);
+        if (url === '/api/services') return jsonResponse([firstDraft, restored]);
+        throw new Error(`unexpected request to ${url}`);
+      },
+    });
+
+    app.boot();
+    await vi.waitFor(() => expect(app.controller().getService()?.id).toBe('restored-draft'));
+    expect(document.getElementById('service-name').value).toBe('Copy of Morning service');
+  });
+
   it('keeps the save live region to its canonical label and puts failure detail in help text', async () => {
     const service = makeService();
     const app = createEditorApp({

--- a/tests/editor-rendering.test.js
+++ b/tests/editor-rendering.test.js
@@ -30,6 +30,93 @@ describe('editor render boundaries', () => {
     expect(app.controller().getService().components[0].reference).toBe('Romans 8:28');
   });
 
+  it('renders every matching song inside the scrollable picker', async () => {
+    const service = makeService({ components: [{ id: 'song-1', type: 'song', title: '', song: null, lyric_slides: [''], credits: '' }] });
+    const songs = Array.from({ length: 20 }, (_, index) => ({
+      id: `song-${index}`,
+      title: `Song ${index + 1}`,
+      variant_label: '',
+      current_version: 1,
+      slide_count: 2,
+    }));
+    const app = createEditorApp({
+      document,
+      request: async url => url.startsWith('/api/songs?') ? jsonResponse(songs) : jsonResponse(service),
+    });
+
+    await app.loadService(service);
+    const search = document.querySelector('.song-picker input[type="search"]');
+    search.dispatchEvent(new Event('focus'));
+
+    await vi.waitFor(() => expect(document.querySelectorAll('.song-choice')).toHaveLength(20));
+    expect(document.querySelector('.song-search-status').textContent).toBe('20 matches.');
+    expect(document.querySelector('.song-picker-results').className).toContain('song-picker-results');
+  });
+
+  it('prefetches Psalm data on intent and reuses it without editing until Load is clicked', async () => {
+    const service = makeService();
+    let psalmRequests = 0;
+    const app = createEditorApp({
+      document,
+      request: async url => {
+        if (url.startsWith('/api/psalm?')) {
+          psalmRequests += 1;
+          return jsonResponse({ reference: 'Psalm 23:1–6', meter: '11 11 11', slides: ['Prepared first', 'Prepared second'] });
+        }
+        return jsonResponse(service);
+      },
+    });
+    await app.loadService(service);
+    document.querySelector('[data-id="psalm-1"] .component-main').click();
+    const load = document.querySelector('[data-loader-kind="psalm"]');
+
+    load.dispatchEvent(new Event('pointerenter'));
+    await vi.waitFor(() => expect(psalmRequests).toBe(1));
+    expect(service.components[1].slide_breaks).toEqual(['The LORD is my shepherd']);
+    expect(app.controller().getState().editGeneration).toBe(0);
+
+    load.click();
+    await vi.waitFor(() => expect(service.components[1].slide_breaks).toEqual(['Prepared first', 'Prepared second']));
+    expect(psalmRequests).toBe(1);
+  });
+
+  it('batches whole-service counts and validation while rapid typing stays immediate', async () => {
+    const components = Array.from({ length: 120 }, (_, index) => ({
+      id: `reading-${index}`,
+      type: 'reading',
+      heading: `Reading ${index + 1}`,
+      reference: 'John 3:16',
+      bible_page: null,
+    }));
+    const service = makeService({ components });
+    let flushDerived;
+    const scheduleFrame = vi.fn(callback => {
+      flushDerived = callback;
+      return 1;
+    });
+    const app = createEditorApp({
+      document,
+      request: async () => jsonResponse(service),
+      scheduleFrame,
+      timers: { setTimeout: vi.fn(() => 1), clearTimeout: vi.fn(), setInterval: vi.fn(), clearInterval: vi.fn() },
+    });
+    await app.loadService(service);
+    const input = document.querySelector('[data-field="reference"]');
+    const originalValidation = document.getElementById('validation-list').firstElementChild;
+
+    for (const value of ['', ' ', '  ', '']) {
+      input.value = value;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    expect(app.controller().getService().components[0].reference).toBe('');
+    expect(scheduleFrame).toHaveBeenCalledOnce();
+    expect(document.getElementById('validation-list').firstElementChild).toBe(originalValidation);
+
+    flushDerived();
+    expect(document.getElementById('validation-list').textContent).toContain('Add a Bible or psalm reference');
+  });
+
   it('updates a heading order item without rebuilding unrelated editor DOM', async () => {
     const service = makeService();
     const app = createEditorApp({ document, request: async () => jsonResponse(service) });
@@ -106,6 +193,7 @@ describe('editor render boundaries', () => {
     const service = makeService();
     const app = createEditorApp({
       document,
+      scheduleFrame: callback => queueMicrotask(callback),
       request: async url => {
         if (url.includes('/psalm?')) return jsonResponse({ reference: 'Psalm 23:1–6', slides: ['First', 'Second'], meter: 'Common metre' });
         return jsonResponse(service);
@@ -378,11 +466,54 @@ describe('editor render boundaries', () => {
     await app.loadService(service);
     const editor = document.getElementById('editor-panel');
     editor.scrollIntoView = vi.fn();
+    const readingItem = document.querySelector('[data-id="reading-1"]');
+    const psalmItem = document.querySelector('[data-id="psalm-1"]');
 
     document.querySelector('[data-id="psalm-1"] .component-main').click();
 
+    expect(document.querySelector('[data-id="reading-1"]')).toBe(readingItem);
+    expect(document.querySelector('[data-id="psalm-1"]')).toBe(psalmItem);
+    expect(readingItem.classList.contains('selected')).toBe(false);
+    expect(psalmItem.classList.contains('selected')).toBe(true);
     expect(editor.scrollTop).toBe(0);
     expect(editor.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+  });
+
+  it('selects a newly added component before its single structural render', async () => {
+    const service = makeService();
+    const app = createEditorApp({
+      document,
+      request: async url => {
+        if (url === '/api/presets' || url === '/api/services') return jsonResponse([]);
+        return jsonResponse(service);
+      },
+    });
+    app.boot();
+    await app.loadService(service);
+
+    document.getElementById('add-component').click();
+
+    const selected = document.querySelector('.component-item.selected');
+    expect(selected.dataset.type).toBe('custom_text_image');
+    expect(app.controller().getState().selectedId).toBe(selected.dataset.id);
+    expect(document.getElementById('editor-panel').textContent).toContain('Custom slides');
+  });
+
+  it('keeps selection correct when duplicating and removing components', async () => {
+    const service = makeService();
+    const app = createEditorApp({ document, request: async () => jsonResponse(service) });
+    await app.loadService(service);
+
+    document.querySelector('[data-id="reading-1"] [aria-label^="Duplicate"]').click();
+    const duplicateId = app.controller().getState().selectedId;
+    expect(duplicateId).not.toBe('reading-1');
+    expect(document.querySelector(`[data-id="${duplicateId}"]`).classList.contains('selected')).toBe(true);
+    expect(app.controller().getService().components[1].id).toBe(duplicateId);
+
+    document.querySelector(`[data-id="${duplicateId}"] [aria-label^="Remove"]`).click();
+    expect(app.controller().getState().selectedId).toBe('psalm-1');
+    expect(document.querySelector('[data-id="psalm-1"]').classList.contains('selected')).toBe(true);
+    expect(document.getElementById('editor-panel').textContent).toContain('Sing Psalms reference');
   });
 
   it('marks song and psalm order items with their type class for highlighting', async () => {

--- a/tests/generated-download.test.js
+++ b/tests/generated-download.test.js
@@ -11,6 +11,7 @@ const RECORD = {
   source_revision: 4,
   download_url: '/api/services/service-1/revisions/26/download',
   snapshot_url: '/api/services/service-1/revisions/26/snapshot',
+  restore_url: '/api/services/service-1/revisions/26/restore',
 };
 
 const SNAPSHOT = {
@@ -38,10 +39,10 @@ async function bootPage(handlers) {
     <button class="sign-out"></button>
     <div id="toast"></div>
   `;
-  global.fetch = vi.fn(async url => {
+  global.fetch = vi.fn(async (url, options) => {
     const handler = handlers[url] || handlers.default;
     if (!handler) throw new Error(`unexpected request to ${url}`);
-    return handler();
+    return handler(options);
   });
   globalThis.URL.createObjectURL = vi.fn(() => 'blob:deck');
   globalThis.URL.revokeObjectURL = vi.fn();
@@ -130,11 +131,61 @@ describe('viewing what a deck was generated from', () => {
     await bootPage({
       '/api/generated': () => ({
         ok: true,
-        json: async () => [{ ...RECORD, snapshot_url: null }],
+        json: async () => [{ ...RECORD, snapshot_url: null, restore_url: null }],
       }),
     });
 
     expect(button('View contents')).toBeUndefined();
+    expect(button('Use as starting point')).toBeUndefined();
     expect(button('Download PowerPoint')).toBeDefined();
+  });
+});
+
+describe('reusing a generated deck in the builder', () => {
+  it('creates a new draft from the saved revision and opens that exact service', async () => {
+    await bootPage({
+      '/api/generated': listingOk,
+      [RECORD.restore_url]: () => ({
+        ok: true,
+        json: async () => ({ ...SNAPSHOT, id: 'restored service/2', name: 'Copy of Morning service' }),
+      }),
+    });
+
+    const anchors = [];
+    const createElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation(tag => {
+      const element = createElement(tag);
+      if (tag === 'a') {
+        element.click = vi.fn();
+        anchors.push(element);
+      }
+      return element;
+    });
+
+    button('Use as starting point').click();
+    await vi.waitFor(() => expect(anchors).toHaveLength(1));
+    const [, options] = global.fetch.mock.calls.find(([url]) => url === RECORD.restore_url);
+    expect(options.method).toBe('POST');
+    expect(options.headers.get('x-csrf-token')).toBe('test-csrf');
+    expect(new URL(anchors[0].href).searchParams.get('service')).toBe('restored service/2');
+    expect(anchors[0].click).toHaveBeenCalled();
+  });
+
+  it('reports a restore failure and leaves the action available to retry', async () => {
+    await bootPage({
+      '/api/generated': listingOk,
+      [RECORD.restore_url]: () => ({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'saved settings are unavailable' }),
+      }),
+    });
+
+    const restore = button('Use as starting point');
+    restore.click();
+    await vi.waitFor(() =>
+      expect(document.getElementById('toast').textContent).toBe('saved settings are unavailable'));
+    expect(restore.disabled).toBe(false);
+    expect(restore.textContent).toBe('Use as starting point');
   });
 });

--- a/tests/request-cache.test.js
+++ b/tests/request-cache.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGetRequestCache } from '../crates/server/static/app.js';
+import { deferred, errorResponse, jsonResponse } from './helpers/editor-fixture.js';
+
+describe('read-only request cache', () => {
+  it('shares an in-flight GET while giving each caller a readable response body', async () => {
+    const request = vi.fn(async () => jsonResponse({ slides: ['one', 'two'] }));
+    const cache = createGetRequestCache(request);
+
+    const [first, second] = await Promise.all([
+      cache.get('/api/psalm?reference=Psalm%2023'),
+      cache.get('/api/psalm?reference=Psalm%2023'),
+    ]);
+
+    expect(request).toHaveBeenCalledOnce();
+    await expect(first.json()).resolves.toEqual({ slides: ['one', 'two'] });
+    await expect(second.json()).resolves.toEqual({ slides: ['one', 'two'] });
+  });
+
+  it('does not retain failed responses and expires successful responses', async () => {
+    let currentTime = 1_000;
+    const request = vi.fn()
+      .mockResolvedValueOnce(errorResponse('temporary failure', 503))
+      .mockResolvedValue(jsonResponse({ ok: true }));
+    const cache = createGetRequestCache(request, { ttlMs: 50, now: () => currentTime });
+
+    expect((await cache.get('/api/scripture?reference=John%203%3A16')).status).toBe(503);
+    expect((await cache.get('/api/scripture?reference=John%203%3A16')).status).toBe(200);
+    currentTime += 51;
+    expect((await cache.get('/api/scripture?reference=John%203%3A16')).status).toBe(200);
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it('lets one consumer time out without cancelling the shared background GET', async () => {
+    const response = deferred();
+    const request = vi.fn(() => response.promise);
+    const cache = createGetRequestCache(request);
+    const abortController = new AbortController();
+
+    const first = cache.get('/api/teaching?source=wsc&selection=1', { signal: abortController.signal });
+    abortController.abort();
+    await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+
+    const second = cache.get('/api/teaching?source=wsc&selection=1');
+    response.resolve(jsonResponse({ question: 'Question', answer: 'Answer' }));
+    await expect((await second).json()).resolves.toEqual({ question: 'Question', answer: 'Answer' });
+    expect(request).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Adds push-to-deploy against the self-hosted server, **without exposing anything to the public internet**.

## How it works

The Coolify instance is bound to loopback and published only on the tailnet via `tailscale serve`. This job joins the tailnet as a short-lived, tagged node for the duration of the run, calls the Coolify API over it, then leaves. There is no inbound webhook, no port forwarding, and no public dashboard — the runner comes *inside* the network rather than the network being opened up.

The job waits for the deployment to reach a terminal state and fails the run if it does not finish cleanly, so a red tick means the site did not change rather than silently diverging from the repo.

## Why this is safe to merge

Coolify builds the new image first and only swaps traffic once the new container is up. A bad commit fails this job and leaves the previous container serving — verified in practice during setup, when an unhealthy container rolled back cleanly with no downtime.

## Setup required before this works

Three repository secrets (Settings → Secrets and variables → Actions):

| Secret | Where it comes from |
|---|---|
| `TS_OAUTH_CLIENT_ID` | Tailscale admin console → Settings → OAuth clients → new client with `auth_keys` write scope, tagged `tag:ci` |
| `TS_OAUTH_SECRET` | same client |
| `COOLIFY_API_TOKEN` | Coolify → Keys & Tokens → API tokens (read/write) |

And one tailnet ACL addition, so CI runners may reach the server:

```json
"tagOwners": { "tag:ci": ["autogroup:admin"] },
"acls": [
  { "action": "accept", "src": ["tag:ci"], "dst": ["homeserver:443"] }
]
```

Until those exist the workflow will fail at the "Join the tailnet" step, which is the intended failure mode — it cannot deploy without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)