### PR TITLE
Cache Rust dependency compilation between builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,37 @@
-FROM rust:1.97.1 AS builder
+# syntax=docker/dockerfile:1
+#
+# Dependency compilation is cached separately from application code.
+#
+# The previous version was:
+#   COPY . .
+#   RUN cargo build --release -p server
+# which makes one layer depend on every file in the repository, so editing a
+# single line of Rust -- or the README -- recompiled all 301 crates in
+# Cargo.lock. That was roughly 5 minutes of an 8 minute build, every time.
+#
+# cargo-chef splits it: `prepare` reduces the workspace to a recipe describing
+# only its dependencies, and `cook` builds those. The cook layer is keyed on the
+# recipe, i.e. on Cargo.toml and Cargo.lock, so it is reused for any change that
+# does not alter dependencies. Change a dependency and it correctly rebuilds.
+
+FROM rust:1.97.1 AS chef
+# Pinned so this layer is stable; it is the slowest thing to rebuild if it ever
+# does get invalidated.
+RUN cargo install cargo-chef --locked --version 0.1.71
 WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Dependencies only. Deliberately not restricted with `-p server`: cooking the
+# whole workspace builds a superset, avoids relying on cargo-chef's argument
+# passthrough, and costs nothing because the result is cached either way.
+RUN cargo chef cook --release --recipe-path recipe.json
+# Only now does application source enter the image, so everything above this
+# line survives an ordinary code change.
 COPY . .
 RUN cargo build --release -p server
 


### PR DESCRIPTION
## What this changes

The builder stage currently ties one Docker layer to every file in the repository:

```dockerfile
COPY . .
RUN cargo build --release -p server
```

So any change — a line of Rust, or the README — invalidates it and recompiles all **301 crates** in `Cargo.lock` before reaching the three workspace crates.

From the last production build's log, the first `Compiling` line appears at 7s and `Compiling server v0.1.0` at **320s**. Over five minutes of every deployment is spent rebuilding dependencies that did not change.

`cargo-chef` splits it in two: `prepare` reduces the workspace to a recipe describing only its dependencies, and `cook` compiles those into their own layer. That layer is keyed on the recipe — effectively `Cargo.toml` and `Cargo.lock` — so it survives any change that does not touch dependencies, and correctly rebuilds when one does.

## Measured

On the deployment host (4 cores, 7GB RAM), building this branch at `3025f54`, then changing a single line in `crates/server/src/lib.rs` and rebuilding:

| | cold build | after a one-line change |
|---|---|---|
| current `Dockerfile` | 358s | **332s** |
| this `Dockerfile` | 400s | **44s** |

Cold builds cost ~42s more, once, to install `cargo-chef` and run the planner stage. Incremental builds go from 332s to 44s.

## Verified

The resulting image was started with the production environment and returned `HTTP 200` from `/healthz`.

## Notes

- `cargo-chef` is pinned to 0.1.71 so the base layer stays stable.
- `cook` deliberately isn't restricted with `-p server`. Cooking the whole workspace builds a superset of what's needed, avoids depending on cargo-chef's argument passthrough, and costs nothing because the result is cached either way.
- The runtime stage is unchanged — still `debian:stable-slim` with just the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
